### PR TITLE
Remove Symfony 2.6 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION=2.3.*
     - php: 5.6
-      env: SYMFONY_VERSION=2.6.*
-    - php: 5.6
       env: SYMFONY_VERSION=2.7.*
     - php: 5.6
       env: SYMFONY_VERSION=2.8.*@dev


### PR DESCRIPTION
This version is not maintained anymore.