### PR TITLE
Missing semicolon in JavaScript

### DIFF
--- a/Resources/public/sonata-dashboard.front.js
+++ b/Resources/public/sonata-dashboard.front.js
@@ -505,4 +505,4 @@ Sonata.Dashboard = {
 
         }
     }
-}
+};


### PR DESCRIPTION
This would break the script when concatenating with other files.