### PR TITLE
Avoid "Notice: Undefined index: type"

### DIFF
--- a/Admin/BlockAdmin.php
+++ b/Admin/BlockAdmin.php
@@ -255,9 +255,7 @@ class BlockAdmin extends Admin
             $parameters['composer'] = $composer;
         }
 
-        if ($composer = $this->getRequest()->get('type')) {
-            $parameters['type'] = $composer;
-        }
+        $parameters['type'] = $this->getRequest()->get('type');
 
         return $parameters;
     }


### PR DESCRIPTION
when "editing widgets" of a dashboard and trying to "add" in the backend, you get that notice because $parameters['type'] is undefined.

NB : it works in SonataPageBundle because BlockAdmin extends BaseBlockAdmin for which getPersistentParameters() sets the key "type" for $parameters

if (!$parameters['type']) in BlockAdminController (line 90) supposes that key "type" for parameters exists