### PR TITLE
Avoid Attempted to call an undefined method named "getName"

### DIFF
--- a/Admin/BlockAdmin.php
+++ b/Admin/BlockAdmin.php
@@ -401,6 +401,14 @@ class BlockAdmin extends Admin
      */
     public function toString($object)
     {
-        return $object->getName();
+    	if (!is_object($object)) {
+    		return '';
+    	}
+    	
+    	if (method_exists($object, 'getName') && null !== $object->getName()) {
+    		return (string) $object->getName();
+    	}
+    	
+    	return parent::toString($object);
     }
 }


### PR DESCRIPTION
Happens when following /admin/dashboard path to visualize SonataAdmin dashboard with SonataDashboardBundle installed.
The override of `toString()` has to test first that the `getName` method exists for the `$object`.