### PR TITLE
BlockAdmin key "type" for parameters and "getName" for object

### DIFF
--- a/Admin/BlockAdmin.php
+++ b/Admin/BlockAdmin.php
@@ -255,9 +255,7 @@ class BlockAdmin extends Admin
             $parameters['composer'] = $composer;
         }
 
-        if ($composer = $this->getRequest()->get('type')) {
-            $parameters['type'] = $composer;
-        }
+        $parameters['type'] = $this->getRequest()->get('type');
 
         return $parameters;
     }
@@ -401,6 +399,13 @@ class BlockAdmin extends Admin
      */
     public function toString($object)
     {
-        return $object->getName();
+        if (!is_object($object)) {
+            return '';
+        }
+        if (method_exists($object, 'getName') && null !== $object->getName()) {
+            return (string) $object->getName();
+        }
+
+        return parent::toString($object);
     }
 }

--- a/Tests/Admin/BlockAdminTest.php
+++ b/Tests/Admin/BlockAdminTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DashboardBundle\Tests\Admin;
+
+use Sonata\AdminBundle\Admin\Admin;
+use Sonata\DashboardBundle\Admin\BlockAdmin;
+use Sonata\DashboardBundle\Tests\Fixtures\Entity\FooGetName;
+use Sonata\DashboardBundle\Tests\Fixtures\Entity\FooGetNameNull;
+use Sonata\DashboardBundle\Tests\Fixtures\Entity\FooNoGetName;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * BlockAdminTest.
+ *
+ * @author Stéphane Paté <st.pate@orange.fr>
+ */
+class BlockAdminTest extends \PHPUnit_Framework_TestCase
+{
+    public function testToString()
+    {
+        $admin = new BlockAdmin(
+            'sonata.dashboard.admin.block',
+            'DashboardBundle\Entity\BaseBlock',
+            'SonataDashboardBundle:BlockAdmin'
+        );
+
+        $s = new FooGetName();
+        $this->assertSame('GetName', $admin->toString($s));
+
+        $s = new FooGetNameNull();
+        $this->assertSame('GetNameNull', $admin->toString($s));
+
+        $s = new FooNoGetName();
+        $this->assertSame('NoGetName', $admin->toString($s));
+    }
+
+    public function testGetPersistentParameters()
+    {
+        $admin = new BlockAdmin(
+            'sonata.dashboard.admin.block',
+            'DashboardBundle\Entity\BaseBlock',
+            'SonataDashboardBundle:BlockAdmin'
+        );
+
+        $request = new Request();
+        $admin->setRequest($request);
+
+        $this->assertArrayHasKey('type', $admin->getPersistentParameters());
+    }
+}

--- a/Tests/Fixtures/Entity/FooGetName.php
+++ b/Tests/Fixtures/Entity/FooGetName.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Sonata\DashboardBundle\Tests\Fixtures\Entity;
+
+class FooGetName
+{
+    public function getName()
+    {
+        return 'GetName';
+    }
+}

--- a/Tests/Fixtures/Entity/FooGetNameNull.php
+++ b/Tests/Fixtures/Entity/FooGetNameNull.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Sonata\DashboardBundle\Tests\Fixtures\Entity;
+
+class FooGetNameNull
+{
+    public function getName()
+    {
+        return;
+    }
+
+    public function __toString()
+    {
+        return 'GetNameNull';
+    }
+}

--- a/Tests/Fixtures/Entity/FooNoGetName.php
+++ b/Tests/Fixtures/Entity/FooNoGetName.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Sonata\DashboardBundle\Tests\Fixtures\Entity;
+
+class FooNoGetName
+{
+    public function __toString()
+    {
+        return 'NoGetName';
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Added
- Added `BlockAdminTest`

### Changed
- Check for a valid object in `BlockAdmin::toString`

### Fixed
- Undefined index: type
- Attempted to call an undefined method named `getName`
```

### Subject

Secure existence in BlockAdmin of key `type` for parameters and `getName` for object