### PR TITLE
Cms Dashboard

### DIFF
--- a/Admin/DashboardAdmin.php
+++ b/Admin/DashboardAdmin.php
@@ -71,8 +71,9 @@ class DashboardAdmin extends Admin
     protected function configureShowFields(ShowMapper $showMapper)
     {
         $showMapper
-            ->add('enabled')
             ->add('name')
+            ->add('isDefault')
+            ->add('enabled')
             ->add('edited')
         ;
     }
@@ -84,6 +85,7 @@ class DashboardAdmin extends Admin
     {
         $listMapper
             ->addIdentifier('name')
+            ->add('isDefault')
             ->add('enabled', null, array('editable' => true))
             ->add('edited', null, array('editable' => true))
         ;
@@ -113,6 +115,7 @@ class DashboardAdmin extends Admin
         $formMapper
             ->with('form_dashboard.group_main_label')
                 ->add('name')
+                ->add('isDefault', null, array('required' => false))
                 ->add('enabled', null, array('required' => false))
             ->end()
         ;

--- a/Admin/DashboardAdmin.php
+++ b/Admin/DashboardAdmin.php
@@ -150,7 +150,7 @@ class DashboardAdmin extends Admin
             $this->trans('sidemenu.link_render_dashboard'),
             array('uri' => $admin->generateUrl('render', array('id' => $id)))
         );
-        
+
         $menu->addChild(
             $this->trans('sidemenu.link_list_blocks'),
             array('uri' => $admin->generateUrl('sonata.dashboard.admin.dashboard|sonata.dashboard.admin.block.list', array('id' => $id)))

--- a/Admin/DashboardAdmin.php
+++ b/Admin/DashboardAdmin.php
@@ -30,6 +30,7 @@ class DashboardAdmin extends Admin
     protected $accessMapping = array(
         'compose' => 'EDIT',
         'composeContainerShow' => 'LIST',
+        'render' => 'EDIT',
     );
 
     /**
@@ -41,6 +42,9 @@ class DashboardAdmin extends Admin
             'id' => null,
         ));
         $collection->add('compose_container_show', 'compose/container/{id}', array(
+            'id' => null,
+        ));
+        $collection->add('render', '{id}/render', array(
             'id' => null,
         ));
     }
@@ -139,7 +143,13 @@ class DashboardAdmin extends Admin
             array('uri' => $admin->generateUrl('compose', array('id' => $id)))
         );
 
-        $menu->addChild('sidemenu.link_list_blocks',
+        $menu->addChild(
+            $this->trans('sidemenu.link_render_dashboard'),
+            array('uri' => $admin->generateUrl('render', array('id' => $id)))
+        );
+        
+        $menu->addChild(
+            $this->trans('sidemenu.link_list_blocks'),
             array('uri' => $admin->generateUrl('sonata.dashboard.admin.dashboard|sonata.dashboard.admin.block.list', array('id' => $id)))
         );
     }

--- a/Block/ContainerBlockService.php
+++ b/Block/ContainerBlockService.php
@@ -68,7 +68,7 @@ class ContainerBlockService extends BaseContainerBlockService
             'layout' => '{{ CONTENT }}',
             'class' => '',
             'color' => '',
-            'template' => 'SonataDashboardBundle:BlockAdmin:block_container.html.twig',
+            'template' => 'SonataDashboardBundle:Block:block_container.html.twig',
         ));
     }
 }

--- a/CmsManager/BaseCmsDashboardManager.php
+++ b/CmsManager/BaseCmsDashboardManager.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DashboardBundle\CmsManager;
+
+use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\DashboardBundle\Model\DashboardInterface;
+
+/**
+ * Base class CMS Manager.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+abstract class BaseCmsDashboardManager implements CmsManagerInterface
+{
+    /**
+     * @var DashboardInterface
+     */
+    protected $currentDashboard;
+
+    /**
+     * @var BlockInterface[]
+     */
+    protected $blocks = array();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCurrentDashboard()
+    {
+        return $this->currentDashboard;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCurrentDashboard(DashboardInterface $dashboard)
+    {
+        $this->currentDashboard = $dashboard;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlocks()
+    {
+        return $this->blocks;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDashboardByName($name)
+    {
+        return $this->getDashboardBy('name', $name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDashboardById($id)
+    {
+        return $this->getDashboardBy('id', $id);
+    }
+
+    /**
+     * @param string $fieldName
+     * @param mixed  $value
+     *
+     * @return DashboardInterface
+     */
+    abstract protected function getDashboardBy($fieldName, $value);
+}

--- a/CmsManager/CmsDashboardManager.php
+++ b/CmsManager/CmsDashboardManager.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DashboardBundle\CmsManager;
+
+use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\DashboardBundle\Exception\DashboardNotFoundException;
+use Sonata\DashboardBundle\Model\BlockInteractorInterface;
+use Sonata\DashboardBundle\Model\DashboardInterface;
+use Sonata\DashboardBundle\Model\DashboardManagerInterface;
+
+/**
+ * The CmsDashboardManager class is in charge of retrieving the dashboard.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+final class CmsDashboardManager extends BaseCmsDashboardManager
+{
+    /**
+     * @var BlockInteractorInterface
+     */
+    private $blockInteractor;
+
+    /**
+     * @var DashboardManagerInterface
+     */
+    private $dashboardManager;
+
+    /**
+     * @var array
+     */
+    private $dashboardReferences = array();
+
+    /**
+     * @var DashboardInterface[]
+     */
+    private $dashboards = array();
+
+    /**
+     * @param DashboardManagerInterface $dashboardManager
+     * @param BlockInteractorInterface  $blockInteractor
+     */
+    public function __construct(DashboardManagerInterface $dashboardManager, BlockInteractorInterface $blockInteractor)
+    {
+        $this->dashboardManager = $dashboardManager;
+        $this->blockInteractor = $blockInteractor;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDashboard($dashboard)
+    {
+        if (is_string($dashboard)) {
+            $dashboard = $this->getDashboardByName($dashboard);
+        } elseif (is_numeric($dashboard)) {
+            $dashboard = $this->getDashboardById($dashboard);
+        } elseif (!$dashboard) { // get the current dashboard
+            $dashboard = $this->getCurrentDashboard();
+        }
+
+        if (!$dashboard instanceof DashboardInterface) {
+            throw new DashboardNotFoundException('Unable to retrieve the dashboard');
+        }
+
+        return $dashboard;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findContainer($code, DashboardInterface $dashboard, BlockInterface $parentContainer = null)
+    {
+        $container = null;
+
+        if ($parentContainer) {
+            // parent container is set, nothing to find, don't need to loop across the
+            // name to find the correct container (main template level)
+            $container = $parentContainer;
+        }
+
+        // first level blocks are containers
+        if (!$container && $dashboard->getBlocks()) {
+            foreach ($dashboard->getBlocks() as $block) {
+                if ($block->getSetting('code') == $code) {
+                    $container = $block;
+                    break;
+                }
+            }
+        }
+
+        if (!$container) {
+            $container = $this->blockInteractor->createNewContainer(array(
+                'enabled' => true,
+                'dashboard' => $dashboard,
+                'code' => $code,
+                'position' => 1,
+                'parent' => $parentContainer,
+            ));
+        }
+
+        return $container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlock($id)
+    {
+        if (!isset($this->blocks[$id])) {
+            $this->blocks[$id] = $this->blockInteractor->getBlock($id);
+        }
+
+        return $this->blocks[$id];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDashboardBy($fieldName, $value)
+    {
+        if ('id' == $fieldName) {
+            $id = $value;
+        } elseif (isset($this->dashboardReferences[$fieldName][$value])) {
+            $id = $this->dashboardReferences[$fieldName][$value];
+        } else {
+            $id = null;
+        }
+
+        if (null === $id || !isset($this->dashboards[$id])) {
+            $this->dashboards[$id] = false;
+
+            $parameters = array(
+                $fieldName => $value,
+            );
+
+            $dashboard = $this->dashboardManager->findOneBy($parameters);
+
+            if (!$dashboard) {
+                throw new DashboardNotFoundException(sprintf('Unable to find the dashboard : %s = %s', $fieldName, $value));
+            }
+
+            $this->loadBlocks($dashboard);
+            $id = $dashboard->getId();
+
+            if ($fieldName != 'id') {
+                $this->dashboardReferences[$fieldName][$value] = $id;
+            }
+
+            $this->dashboards[$id] = $dashboard;
+        }
+
+        return $this->dashboards[$id];
+    }
+
+    /**
+     * load all the related nested blocks linked to one dashboard.
+     *
+     * @param DashboardInterface $dashboard
+     */
+    private function loadBlocks(DashboardInterface $dashboard)
+    {
+        $blocks = $this->blockInteractor->loadDashboardBlocks($dashboard);
+
+        // save a local cache
+        foreach ($blocks as $block) {
+            $this->blocks[$block->getId()] = $block;
+        }
+    }
+}

--- a/CmsManager/CmsManagerInterface.php
+++ b/CmsManager/CmsManagerInterface.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DashboardBundle\CmsManager;
+
+use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\DashboardBundle\Model\DashboardInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * The CmsManagerInterface class is in charge of retrieving the correct dashboard.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+interface CmsManagerInterface
+{
+    /**
+     * @param string              $name
+     * @param DashboardInterface  $dashboard
+     * @param null|BlockInterface $parentContainer
+     *
+     * @return bool|null|BlockInterface
+     */
+    public function findContainer($name, DashboardInterface $dashboard, BlockInterface $parentContainer = null);
+
+    /**
+     * Returns a fully loaded dashboard (+ blocks) from a name.
+     *
+     * @param string $name
+     *
+     * @return DashboardInterface
+     */
+    public function getDashboardByName($name);
+
+    /**
+     * Returns a fully loaded pag (+ blocks) from a dashboard id.
+     *
+     * @param int $id
+     *
+     * @return DashboardInterface
+     */
+    public function getDashboardById($id);
+
+    /**
+     * @param int $id
+     *
+     * @return DashboardInterface
+     */
+    public function getBlock($id);
+
+    /**
+     * Returns the current dashboard.
+     *
+     * @return DashboardInterface
+     */
+    public function getCurrentDashboard();
+
+    /**
+     * @param DashboardInterface $dashboard
+     */
+    public function setCurrentDashboard(DashboardInterface $dashboard);
+
+    /**
+     * Returns the list of loaded block from the current http request.
+     *
+     * @return BlockInterface[]
+     */
+    public function getBlocks();
+
+    /**
+     * @param string $dashboard
+     *
+     * @return DashboardInterface
+     */
+    public function getDashboard($dashboard);
+}

--- a/CmsManager/CmsManagerSelector.php
+++ b/CmsManager/CmsManagerSelector.php
@@ -11,7 +11,6 @@
 
 namespace Sonata\DashboardBundle\CmsManager;
 
-use Sonata\DashboardBundle\CmsManager\CmsManagerInterface;
 use Sonata\DashboardBundle\Exception\DashboardNotFoundException;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
@@ -23,17 +22,17 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 final class CmsManagerSelector implements CmsManagerSelectorInterface
-{    
+{
     private $cmsDashboardManager;
-    
+
     private $authorizationChecker;
-    
+
     public function __construct(AuthorizationCheckerInterface $authorizationChecker, CmsManagerInterface $cmsDashboardManager)
     {
-        $this->cmsDashboardManager = $cmsDashboardManager; 
+        $this->cmsDashboardManager = $cmsDashboardManager;
         $this->authorizationChecker = $authorizationChecker;
     }
-    
+
     /**
      * {@inheritdoc}
      */

--- a/CmsManager/CmsManagerSelector.php
+++ b/CmsManager/CmsManagerSelector.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DashboardBundle\CmsManager;
+
+use Sonata\DashboardBundle\CmsManager\CmsManagerInterface;
+use Sonata\DashboardBundle\Exception\DashboardNotFoundException;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+/**
+ * This class return the correct manager instance :
+ *   - sonata.dashboard.cms.dashboard if the user is an editor (ROLE_SONATA_DASHBOARD_ADMIN_DASHBOARD_EDIT)
+ *   - not found exception if the user is a standard user.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+final class CmsManagerSelector implements CmsManagerSelectorInterface
+{    
+    private $cmsDashboardManager;
+    
+    private $authorizationChecker;
+    
+    public function __construct(AuthorizationCheckerInterface $authorizationChecker, CmsManagerInterface $cmsDashboardManager)
+    {
+        $this->cmsDashboardManager = $cmsDashboardManager; 
+        $this->authorizationChecker = $authorizationChecker;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function retrieve()
+    {
+        if ($this->isEditor()) {
+            return $manager = $this->cmsDashboardManager;
+        }
+
+        throw new DashboardNotFoundException('Unable to retrieve the cms manager');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isEditor()
+    {
+        return $this->authorizationChecker->isGranted('ROLE_SONATA_DASHBOARD_ADMIN_DASHBOARD_EDIT');
+    }
+}

--- a/CmsManager/CmsManagerSelectorInterface.php
+++ b/CmsManager/CmsManagerSelectorInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DashboardBundle\CmsManager;
+
+/**
+ * The CmsManagerSelectorInterface is in charge of retrieving the correct CmsManagerInterface instance.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+interface CmsManagerSelectorInterface
+{
+    /**
+     * @return CmsManagerInterface
+     */
+    public function retrieve();
+
+    /**
+     * @return bool
+     */
+    public function isEditor();
+}

--- a/Controller/DashboardAdminController.php
+++ b/Controller/DashboardAdminController.php
@@ -125,6 +125,10 @@ class DashboardAdminController extends CRUDController
             }
         }
 
+        $dashboards = $this->get('sonata.dashboard.manager.dashboard')->findBy(
+            array(), array('updatedAt' => 'DESC'), 5
+        );
+
         $csrfProvider = $this->get('form.csrf_provider');
 
         return $this->render($this->admin->getTemplate('render'), array(
@@ -132,6 +136,7 @@ class DashboardAdminController extends CRUDController
             'default' => $default,
             'action' => 'edit',
             'containers' => $containers,
+            'dashboards' => $dashboards,
             'csrfTokens' => array(
                 'remove' => $csrfProvider->generateCsrfToken('sonata.delete'),
             ),

--- a/Controller/DashboardAdminController.php
+++ b/Controller/DashboardAdminController.php
@@ -56,7 +56,7 @@ class DashboardAdminController extends CRUDController
 
         $csrfProvider = $this->get('form.csrf_provider');
 
-        return $this->render($template = $this->admin->getTemplate('compose'), array(
+        return $this->render($this->admin->getTemplate('compose'), array(
             'object' => $dashboard,
             'action' => 'edit',
             'containers' => $containers,
@@ -85,10 +85,56 @@ class DashboardAdminController extends CRUDController
 
         $blockServices = $this->get('sonata.block.manager')->getServicesByContext('sonata_dashboard_bundle', false);
 
-        return $this->render($template = $this->admin->getTemplate('compose_container_show'), array(
+        return $this->render($this->admin->getTemplate('compose_container_show'), array(
             'blockServices' => $blockServices,
             'container' => $block,
             'dashboard' => $block->getDashboard(),
+        ));
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return Response
+     *
+     * @throws AccessDeniedException
+     */
+    public function renderAction(Request $request = null)
+    {
+        $this->admin->checkAccess('render');
+        if (false === $this->get('sonata.dashboard.admin.block')->isGranted('LIST')) {
+            throw new AccessDeniedException();
+        }
+
+        // when true renders the dashboard as with sonata_admin_dashboard route
+        $default = false;
+        
+        $id = $request->get($this->admin->getIdParameter());
+        $dashboard = $this->admin->getObject($id);
+        if (!$dashboard) {
+            throw new NotFoundHttpException(sprintf('unable to find the dashboard with id : %s', $id));
+        }
+    
+        $containers = array();
+    
+        // separate containers
+        foreach ($dashboard->getBlocks() as $block) {
+            $blockCode = $block->getSetting('code');
+            if ($block->getParent() === null) {
+                $containers[$blockCode] = $block;
+            }
+        }
+    
+        $csrfProvider = $this->get('form.csrf_provider');
+
+        return $this->render($this->admin->getTemplate('render'), array(
+            'object'     => $dashboard,
+            'default'    => $default,
+            'action'     => 'edit',
+            'containers' => $containers,
+            'csrfTokens' => array(
+                'remove' => $csrfProvider->generateCsrfToken('sonata.delete'),
+            ),
         ));
     }
 }

--- a/Controller/DashboardAdminController.php
+++ b/Controller/DashboardAdminController.php
@@ -106,17 +106,17 @@ class DashboardAdminController extends CRUDController
             throw new AccessDeniedException();
         }
 
-        // when true renders the dashboard as with sonata_admin_dashboard route
-        $default = false;
-        
+        // true when renders default dashboard from sonata_admin_dashboard redirect
+        $default = $request->query->get('default');
+
         $id = $request->get($this->admin->getIdParameter());
         $dashboard = $this->admin->getObject($id);
         if (!$dashboard) {
             throw new NotFoundHttpException(sprintf('unable to find the dashboard with id : %s', $id));
         }
-    
+
         $containers = array();
-    
+
         // separate containers
         foreach ($dashboard->getBlocks() as $block) {
             $blockCode = $block->getSetting('code');
@@ -124,13 +124,13 @@ class DashboardAdminController extends CRUDController
                 $containers[$blockCode] = $block;
             }
         }
-    
+
         $csrfProvider = $this->get('form.csrf_provider');
 
         return $this->render($this->admin->getTemplate('render'), array(
-            'object'     => $dashboard,
-            'default'    => $default,
-            'action'     => 'edit',
+            'object' => $dashboard,
+            'default' => $default,
+            'action' => 'edit',
             'containers' => $containers,
             'csrfTokens' => array(
                 'remove' => $csrfProvider->generateCsrfToken('sonata.delete'),

--- a/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
+++ b/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DashboardBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * GlobalVariablesCompilerPass.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+class GlobalVariablesCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $container->getDefinition('twig')
+            ->addMethodCall('addGlobal', array('sonata_dashboard', new Reference('sonata.dashboard.twig.global')));
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -57,6 +57,10 @@ class Configuration implements ConfigurationInterface
                         ->defaultValue('SonataDashboardBundle:DashboardAdmin:compose_container_show.html.twig')
                         ->info('This value sets the container composer template.')
                     ->end()
+                    ->scalarNode('render')
+                        ->defaultValue('SonataDashboardBundle:DashboardAdmin:render.html.twig')
+                        ->info('This value sets the render template.')
+                    ->end()
                 ->end()
             ->end()
         ;

--- a/DependencyInjection/SonataDashboardExtension.php
+++ b/DependencyInjection/SonataDashboardExtension.php
@@ -40,6 +40,7 @@ class SonataDashboardExtension extends Extension
         $loader->load('admin.xml');
         $loader->load('block.xml');
         $loader->load('orm.xml');
+        $loader->load('twig.xml');
 
         $this->registerDoctrineMapping($config);
         $this->registerParameters($container, $config);
@@ -178,6 +179,8 @@ class SonataDashboardExtension extends Extension
             'Sonata\\DashboardBundle\\Model\\DashboardBlockInterface',
             'Sonata\\DashboardBundle\\Model\\DashboardInterface',
             'Sonata\\DashboardBundle\\Model\\DashboardManagerInterface',
+            'Sonata\\DashboardBundle\\Twig\\Extension\\DashboardExtension',
+            'Sonata\\DashboardBundle\\Twig\\GlobalVariables',
         ));
     }
 }

--- a/DependencyInjection/SonataDashboardExtension.php
+++ b/DependencyInjection/SonataDashboardExtension.php
@@ -68,7 +68,11 @@ class SonataDashboardExtension extends Extension
             'sonata.dashboard.admin.dashboard.templates.compose_container_show',
             $config['templates']['compose_container_show']
         );
-
+        $container->setParameter(
+            'sonata.dashboard.admin.dashboard.templates.render',
+            $config['templates']['render']
+        );
+        
         //@todo : check this container is a service
         //if (!$container->hasDefinition($config['default_container'])) {
         //    throw new \RuntimeException(sprintf('The container %s must be an existing service', $config['default_container']));

--- a/DependencyInjection/SonataDashboardExtension.php
+++ b/DependencyInjection/SonataDashboardExtension.php
@@ -36,6 +36,7 @@ class SonataDashboardExtension extends Extension
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
+        $loader->load('dashboard.xml');
         $loader->load('admin.xml');
         $loader->load('block.xml');
         $loader->load('orm.xml');
@@ -161,12 +162,17 @@ class SonataDashboardExtension extends Extension
     {
         $this->addClassesToCompile(array(
             'Sonata\\DashboardBundle\\Block\\ContainerBlockService',
+            'Sonata\\DashboardBundle\\CmsManager\\CmsManagerInterface',
+            'Sonata\\DashboardBundle\\CmsManager\\CmsManagerSelector',
+            'Sonata\\DashboardBundle\\CmsManager\\CmsManagerSelectorInterface',
+            'Sonata\\DashboardBundle\\CmsManager\\CmsDashboardManager',
             'Sonata\\DashboardBundle\\Entity\\BaseBlock',
             'Sonata\\DashboardBundle\\Entity\\BaseDashboard',
             'Sonata\\DashboardBundle\\Entity\\BlockInteractor',
             'Sonata\\DashboardBundle\\Entity\\BlockManager',
             'Sonata\\DashboardBundle\\Entity\\DashboardManager',
             'Sonata\\DashboardBundle\\Model\\Block',
+            'Sonata\\DashboardBundle\\Model\\BlockManagerInterface',
             'Sonata\\DashboardBundle\\Model\\BlockInteractorInterface',
             'Sonata\\DashboardBundle\\Model\\Dashboard',
             'Sonata\\DashboardBundle\\Model\\DashboardBlockInterface',

--- a/DependencyInjection/SonataDashboardExtension.php
+++ b/DependencyInjection/SonataDashboardExtension.php
@@ -36,9 +36,10 @@ class SonataDashboardExtension extends Extension
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
-        $loader->load('dashboard.xml');
         $loader->load('admin.xml');
         $loader->load('block.xml');
+        $loader->load('dashboard.xml');
+        $loader->load('http_kernel.xml');
         $loader->load('orm.xml');
         $loader->load('twig.xml');
 
@@ -72,7 +73,7 @@ class SonataDashboardExtension extends Extension
             'sonata.dashboard.admin.dashboard.templates.render',
             $config['templates']['render']
         );
-        
+
         //@todo : check this container is a service
         //if (!$container->hasDefinition($config['default_container'])) {
         //    throw new \RuntimeException(sprintf('The container %s must be an existing service', $config['default_container']));
@@ -176,6 +177,7 @@ class SonataDashboardExtension extends Extension
             'Sonata\\DashboardBundle\\Entity\\BlockInteractor',
             'Sonata\\DashboardBundle\\Entity\\BlockManager',
             'Sonata\\DashboardBundle\\Entity\\DashboardManager',
+            'Sonata\\DashboardBundle\\Listener\\RequestListener',
             'Sonata\\DashboardBundle\\Model\\Block',
             'Sonata\\DashboardBundle\\Model\\BlockManagerInterface',
             'Sonata\\DashboardBundle\\Model\\BlockInteractorInterface',

--- a/Listener/RequestListener.php
+++ b/Listener/RequestListener.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DashboardBundle\Listener;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+/**
+ * This class redirect the onKernelRequest event
+ * to the correct DashboardAdminController action.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+class RequestListener
+{
+    /**
+     * @var AdminInterface
+     */
+    protected $admin;
+
+    /**
+     * Constructor.
+     *
+     * @param AdminInterface $admin Dashboard admin
+     */
+    public function __construct(AdminInterface $admin)
+    {
+        $this->admin = $admin;
+    }
+
+    /**
+     * Filter the `kernel.request` event to catch the dashboardAction.
+     *
+     * @param GetResponseEvent $event
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        if ($event->getRequest()->get('_route') == 'sonata_admin_dashboard') {
+            $modelManager = $this->admin->getModelManager();
+
+            $defaultDashboard = $modelManager->findOneBy(
+                $this->admin->getClass(),
+                array('isDefault' => true, 'enabled' => true)
+            );
+
+            if ($defaultDashboard) {
+                $url = $this->admin->generateObjectUrl('render', $defaultDashboard, array('default' => true));
+                $event->setResponse(new RedirectResponse($url));
+            }
+        }
+    }
+}

--- a/Model/Dashboard.php
+++ b/Model/Dashboard.php
@@ -54,6 +54,11 @@ abstract class Dashboard implements DashboardInterface
     protected $edited;
 
     /**
+     * @var bool
+     */
+    protected $isDefault;
+
+    /**
      * {@inheritdoc}
      */
     public function __construct()
@@ -168,6 +173,22 @@ abstract class Dashboard implements DashboardInterface
         $this->edited = $edited;
 
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setIsDefault($default)
+    {
+        $this->isDefault = $default;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIsDefault()
+    {
+        return $this->isDefault;
     }
 
     /**

--- a/Model/DashboardInterface.php
+++ b/Model/DashboardInterface.php
@@ -97,6 +97,18 @@ interface DashboardInterface
     public function getUpdatedAt();
 
     /**
+     * @return bool
+     */
+    public function getIsDefault();
+
+    /**
+     * @param bool $default
+     *
+     * @return DashboardInterface
+     */
+    public function setIsDefault($default);
+
+    /**
      * Add blocs.
      *
      * @param DashboardBlockInterface $block

--- a/Resources/config/admin.xml
+++ b/Resources/config/admin.xml
@@ -26,6 +26,7 @@
                 <argument type="collection">
                     <argument key="compose">%sonata.dashboard.admin.dashboard.templates.compose%</argument>
                     <argument key="compose_container_show">%sonata.dashboard.admin.dashboard.templates.compose_container_show%</argument>
+                    <argument key="render">%sonata.dashboard.admin.dashboard.templates.render%</argument>
                 </argument>
             </call>
         </service>

--- a/Resources/config/dashboard.xml
+++ b/Resources/config/dashboard.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sonata.dashboard.cms.dashboard" class="Sonata\DashboardBundle\CmsManager\CmsDashboardManager">
+            <tag name="sonata.dashboard.manager" type="dashboard"/>
+            <argument type="service" id="sonata.dashboard.manager.dashboard"/>
+            <argument type="service" id="sonata.dashboard.block_interactor"/>
+        </service>
+        <service id="sonata.dashboard.cms_manager_selector" class="Sonata\DashboardBundle\CmsManager\CmsManagerSelector">
+            <argument type="service" id="security.authorization_checker"/>
+            <argument type="service" id="sonata.dashboard.cms.dashboard"/>
+        </service>
+    </services>
+</container>

--- a/Resources/config/doctrine/BaseDashboard.orm.xml
+++ b/Resources/config/doctrine/BaseDashboard.orm.xml
@@ -3,6 +3,7 @@
     <mapped-superclass name="Sonata\DashboardBundle\Entity\BaseDashboard">
         <field name="enabled" type="boolean" column="enabled" default="false"/>
         <field name="edited" type="boolean" column="edited" default="false"/>
+        <field name="isDefault" type="boolean" column="is_default" default="false"/>
         <field name="name" type="string" column="name" length="255"/>
         <field name="createdAt" type="datetime" column="created_at"/>
         <field name="updatedAt" type="datetime" column="updated_at"/>

--- a/Resources/config/http_kernel.xml
+++ b/Resources/config/http_kernel.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sonata.dashboard.kernel.request_listener" class="Sonata\DashboardBundle\Listener\RequestListener">
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="-2"/>
+            <argument type="service" id="sonata.dashboard.admin.dashboard"/>
+        </service>
+    </services>
+</container>

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sonata.dashboard.twig.extension" class="Sonata\DashboardBundle\Twig\Extension\DashboardExtension" public="false">
+            <tag name="twig.extension"/>
+            <argument type="service" id="sonata.dashboard.cms_manager_selector"/>
+            <argument type="service" id="sonata.block.templating.helper"/>
+        </service>
+        <service id="sonata.dashboard.twig.global" class="Sonata\DashboardBundle\Twig\GlobalVariables">
+            <argument type="service" id="sonata.dashboard.cms_manager_selector"/>
+        </service>
+    </services>
+</container>

--- a/Resources/translations/SonataDashboardBundle.en.xliff
+++ b/Resources/translations/SonataDashboardBundle.en.xliff
@@ -214,6 +214,10 @@
                 <source>sidemenu.link_render_dashboard</source>
                 <target>View Dashboard</target>
             </trans-unit>
+            <trans-unit id="54" resname="dashboard.render_dashboard">
+                <source>dashboard.render_dashboard</source>
+                <target>View of </target>
+            </trans-unit>
             <trans-unit id="55" resname="breadcrumb.link_dashboard_render">
                 <source>breadcrumb.link_dashboard_render</source>
                 <target>View Dashboard</target>

--- a/Resources/translations/SonataDashboardBundle.en.xliff
+++ b/Resources/translations/SonataDashboardBundle.en.xliff
@@ -50,13 +50,9 @@
                 <source>breadcrumb.link_dashboard_show</source>
                 <target>Show</target>
             </trans-unit>
-            <trans-unit id="12" resname="dashboard.compose_dashboard">
-                <source>dashboard.compose_dashboard</source>
-                <target>Compose </target>
-            </trans-unit>
             <trans-unit id="13" resname="sidemenu.link_edit_dashboard">
                 <source>sidemenu.link_edit_dashboard</source>
-                <target>Edit Dashboard</target>
+                <target>Edit</target>
             </trans-unit>
             <trans-unit id="14" resname="sidemenu.link_list_blocks">
                 <source>sidemenu.link_list_blocks</source>
@@ -64,7 +60,7 @@
             </trans-unit>
             <trans-unit id="15" resname="sidemenu.link_compose_dashboard">
                 <source>sidemenu.link_compose_dashboard</source>
-                <target>Composer (beta)</target>
+                <target>Compose</target>
             </trans-unit>
             <trans-unit id="16" resname="sidemenu.link_list_dashboards">
                 <source>sidemenu.link_list_dashboards</source>
@@ -213,6 +209,34 @@
             <trans-unit id="52" resname="form.label_template">
                 <source>form.label_template</source>
                 <target>Template</target>
+            </trans-unit>
+            <trans-unit id="53" resname="sidemenu.link_render_dashboard">
+                <source>sidemenu.link_render_dashboard</source>
+                <target>View Dashboard</target>
+            </trans-unit>
+            <trans-unit id="55" resname="breadcrumb.link_dashboard_render">
+                <source>breadcrumb.link_dashboard_render</source>
+                <target>View Dashboard</target>
+            </trans-unit>
+            <trans-unit id="56" resname="form.label_is_default">
+                <source>form.label_is_default</source>
+                <target>Default</target>
+            </trans-unit>
+            <trans-unit id="57" resname="list.label_is_default">
+                <source>list.label_is_default</source>
+                <target>Default</target>
+            </trans-unit>
+            <trans-unit id="58" resname="show.label_is_default">
+                <source>show.label_is_default</source>
+                <target>Default</target>
+            </trans-unit>
+            <trans-unit id="59" resname="title_render">
+                <source>title_render</source>
+                <target>View "%name%"</target>
+            </trans-unit>
+            <trans-unit id="60" resname="title_compose">
+                <source>title_compose</source>
+                <target>Compose "%name%"</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/SonataDashboardBundle.en.xliff
+++ b/Resources/translations/SonataDashboardBundle.en.xliff
@@ -242,6 +242,10 @@
                 <source>title_compose</source>
                 <target>Compose "%name%"</target>
             </trans-unit>
+            <trans-unit id="61" resname="title_navbar">
+                <source>title_navbar</source>
+                <target>View</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataDashboardBundle.fr.xliff
+++ b/Resources/translations/SonataDashboardBundle.fr.xliff
@@ -274,6 +274,10 @@
                 <source>title_compose</source>
                 <target>Composer "%name%"</target>
             </trans-unit>
+            <trans-unit id="70" resname="title_navbar">
+                <source>title_navbar</source>
+                <target>Apercevoir</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataDashboardBundle.fr.xliff
+++ b/Resources/translations/SonataDashboardBundle.fr.xliff
@@ -50,13 +50,9 @@
                 <source>breadcrumb.link_dashboard_show</source>
                 <target>Tableau de bord</target>
             </trans-unit>
-            <trans-unit id="12" resname="dashboard.compose_dashboard">
-                <source>dashboard.compose_dashboard</source>
-                <target>Mise en page du tableau de bord </target>
-            </trans-unit>
             <trans-unit id="13" resname="sidemenu.link_edit_dashboard">
                 <source>sidemenu.link_edit_dashboard</source>
-                <target>Edition du tableau de bord</target>
+                <target>Edition</target>
             </trans-unit>
             <trans-unit id="14" resname="sidemenu.link_list_blocks">
                 <source>sidemenu.link_list_blocks</source>
@@ -64,7 +60,7 @@
             </trans-unit>
             <trans-unit id="15" resname="sidemenu.link_compose_dashboard">
                 <source>sidemenu.link_compose_dashboard</source>
-                <target>Composition du tableau de bord</target>
+                <target>Composition</target>
             </trans-unit>
             <trans-unit id="16" resname="sidemenu.link_list_dashboards">
                 <source>sidemenu.link_list_dashboards</source>
@@ -249,6 +245,34 @@
             <trans-unit id="61" resname="show.label_edited">
                 <source>show.label_edited</source>
                 <target>Edité</target>
+            </trans-unit>
+            <trans-unit id="62" resname="sidemenu.link_render_dashboard">
+                <source>sidemenu.link_render_dashboard</source>
+                <target>Aperçu</target>
+            </trans-unit>
+            <trans-unit id="64" resname="breadcrumb.link_dashboard_render">
+                <source>breadcrumb.link_dashboard_render</source>
+                <target>Aperçu d'un tableau de bord</target>
+            </trans-unit>
+            <trans-unit id="65" resname="form.label_is_default">
+                <source>form.label_is_default</source>
+                <target>Par défaut</target>
+            </trans-unit>
+            <trans-unit id="66" resname="list.label_is_default">
+                <source>list.label_is_default</source>
+                <target>Par défaut</target>
+            </trans-unit>
+            <trans-unit id="67" resname="show.label_is_default">
+                <source>show.label_is_default</source>
+                <target>Par défaut</target>
+            </trans-unit>
+            <trans-unit id="68" resname="title_render">
+                <source>title_render</source>
+                <target>Apercevoir "%name%"</target>
+            </trans-unit>
+            <trans-unit id="69" resname="title_compose">
+                <source>title_compose</source>
+                <target>Composer "%name%"</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/views/Block/block_container.html.twig
+++ b/Resources/views/Block/block_container.html.twig
@@ -1,0 +1,29 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends sonata_block.templates.block_base %}
+
+{# block classes are prepended with a container class #}
+{% block block_class %} cms-container{% if not block.hasParent() %} cms-container-root{%endif%}{% if settings.class %} {{ settings.class }}{% endif %}{% endblock %}
+
+{# identify a block role used by the page editor #}
+{% block block_role %}container{% endblock %}
+
+{# render container block #}
+{% block block %}
+    {% if decorator %}{{ decorator.pre|raw }}{% endif %}
+    {% for child in block.children %}
+        {% block block_child_render %}
+            {{ sonata_block_render(child) }}
+        {% endblock %}
+    {% endfor %}
+    {% if decorator %}{{ decorator.post|raw }}{% endif %}
+{% endblock %}

--- a/Resources/views/DashboardAdmin/compose.html.twig
+++ b/Resources/views/DashboardAdmin/compose.html.twig
@@ -13,10 +13,16 @@ file that was distributed with this source code.
 
 {% block body_attributes %}class="sonata-bc skin-black fixed dashboard-composer-dashboard sonata-ba-no-side-menu"{% endblock %}
 
+{% block title %}
+    {{ "title_compose"|trans({'%name%': admin.toString(object)|truncate(15) }, 'SonataDashboardBundle') }}
+{% endblock %}
+
+{% block navbar_title %}
+    {{ block('title') }}
+{% endblock %}
+
 {% block content %}
     <div class="dashboard-composer">
-        <h2>{{ 'dashboard.compose_dashboard'|trans({}, 'SonataDashboardBundle') }} "{{ object.name }}"</h2>
-
         <div class="row row-fluid">
             <div class="col-md-4 span4">
                 <div class="dashboard-composer__dashboard-preview">
@@ -66,6 +72,5 @@ file that was distributed with this source code.
                 window.SonataDashboardComposer = composer;
             });
         </script>
-
     </div>
 {% endblock %}

--- a/Resources/views/DashboardAdmin/render.html.twig
+++ b/Resources/views/DashboardAdmin/render.html.twig
@@ -1,0 +1,46 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends 'SonataAdminBundle:CRUD:action.html.twig' %}
+
+{% block sonata_breadcrumb %}
+    {% if not default == true %}
+            {{ parent() }}
+    {% endif %}
+{% endblock %}
+
+{% block title %}
+    {{ "title_render"|trans({'%name%': admin.toString(object)|truncate(15) }, 'SonataDashboardBundle') }}
+{% endblock %}
+
+{% block navbar_title %}
+    {{ block('title') }}
+{% endblock %}
+
+{% block sonata_page_content %}
+    {% if default == true %}
+        <section class="content">
+            <div class="sonata-ba-content">                
+                {{ block('content') }}
+            </div>
+        </section> 
+    {% else %}
+        {{ parent() }}
+    {% endif %}
+{% endblock %}
+
+{% block content %}
+    <div class="row">
+        {% for code, container in containers %}
+            {{ sonata_dashboard_render_container(container.name, object) }}
+        {% endfor %}                                    
+    </div>
+{% endblock %}

--- a/Resources/views/DashboardAdmin/render.html.twig
+++ b/Resources/views/DashboardAdmin/render.html.twig
@@ -18,11 +18,34 @@ file that was distributed with this source code.
 {% endblock %}
 
 {% block title %}
-    {{ "title_render"|trans({'%name%': admin.toString(object)|truncate(15) }, 'SonataDashboardBundle') }}
+    {{ 'title_render'|trans({'%name%': admin.toString(object)|truncate(15) }, 'SonataDashboardBundle') }}
 {% endblock %}
 
-{% block navbar_title %}
-    {{ block('title') }}
+{% block tab_menu_navbar_header %}
+<div class="navbar-header">
+    <p class="navbar-text">
+        {{ 'title_navbar'|trans({}, 'SonataDashboardBundle') }}
+    </p>                      
+    <ul class="nav navbar-nav"> 
+        <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="true">{{ object.name }} <span class="caret"></span></a>
+            <ul class="dropdown-menu" role="menu">
+                {% for dashboard in dashboards %}
+                <li>
+                    <a href="{{ admin.generateUrl('render', { 'id': dashboard.id }) }}">
+                        {% if object and dashboard.id == object.id %}
+                            <span class="pull-right">
+                                <i class="fa fa-check"></i>
+                            </span>
+                        {% endif %}
+                        {{ dashboard.name }}
+                    </a>
+                </li>
+                {% endfor%}
+            </ul>
+        </li>
+    </ul>
+</div>
 {% endblock %}
 
 {% block sonata_page_content %}

--- a/SonataDashboardBundle.php
+++ b/SonataDashboardBundle.php
@@ -12,6 +12,8 @@
 namespace Sonata\DashboardBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Sonata\DashboardBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
 
 /**
  * Class SonataDashboardBundle.
@@ -20,4 +22,11 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class SonataDashboardBundle extends Bundle
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new GlobalVariablesCompilerPass());
+    }
 }

--- a/SonataDashboardBundle.php
+++ b/SonataDashboardBundle.php
@@ -11,9 +11,9 @@
 
 namespace Sonata\DashboardBundle;
 
-use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Sonata\DashboardBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * Class SonataDashboardBundle.

--- a/Tests/CmsManager/CmsDashboardManagerTest.php
+++ b/Tests/CmsManager/CmsDashboardManagerTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DashboardBundle\Tests\Dashboard;
+
+use Sonata\DashboardBundle\CmsManager\CmsDashboardManager;
+use Sonata\DashboardBundle\Tests\Fixtures\Entity\CmsBlock;
+use Sonata\DashboardBundle\Tests\Model\Dashboard;
+
+final class CmsDashboardManagerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CmsDashboardManager
+     */
+    private $manager;
+
+    /**
+     * Setup manager object to test.
+     */
+    public function setUp()
+    {
+        $this->blockInteractor = $this->getMockBlockInteractor();
+        $this->dashboardManager = $this->getMock('Sonata\DashboardBundle\Model\DashboardManagerInterface');
+        $this->manager = new CmsDashboardManager($this->dashboardManager, $this->blockInteractor);
+    }
+
+    /**
+     * Test finding an existing container in a dashboard.
+     */
+    public function testFindExistingContainer()
+    {
+        $block = new CmsBlock();
+        $block->setSettings(array('code' => 'findme'));
+
+        $dashboard = new Dashboard();
+        $dashboard->addBlocks($block);
+
+        $container = $this->manager->findContainer('findme', $dashboard);
+
+        $this->assertEquals(spl_object_hash($block), spl_object_hash($container),
+            'should retrieve the block of the dashboard');
+    }
+
+    /**
+     * Test finding an non-existing container in a dashboard does create a new block.
+     */
+    public function testFindNonExistingContainerCreatesNewBlock()
+    {
+        $dashboard = new Dashboard();
+
+        $container = $this->manager->findContainer('newcontainer', $dashboard);
+
+        $this->assertInstanceOf('Sonata\DashboardBundle\Model\DashboardBlockInterface', $container, 'should be a block');
+        $this->assertEquals('newcontainer', $container->getSetting('code'));
+    }
+
+    /**
+     * Test get Dashboard method with id return Dashboard.
+     */
+    public function testGetDashboardWithId()
+    {
+        $dashboardManager = $this->getMock('Sonata\DashboardBundle\Model\DashboardManagerInterface');
+
+        $dashboardManager->expects($this->any())->method('findOneBy')->will($this->returnValue(new Dashboard()));
+        $this->blockInteractor->expects($this->any())->method('loadDashboardBlocks')->will($this->returnValue(array()));
+
+        $manager = $this->createManager($dashboardManager, $this->blockInteractor);
+
+        $dashboard = 1;
+
+        $this->assertInstanceOf('Sonata\DashboardBundle\Model\DashboardInterface', $manager->getDashboard($dashboard));
+    }
+
+    /**
+     * Test get Dashboard method with id throw Exception.
+     */
+    public function testGetDashboardWithIdException()
+    {
+        $dashboardManager = $this->getMock('Sonata\DashboardBundle\Model\DashboardManagerInterface');
+
+        $this->blockInteractor->expects($this->any())->method('loadDashboardBlocks')->will($this->returnValue(array()));
+
+        $manager = $this->createManager($dashboardManager, $this->blockInteractor);
+
+        $dashboard = 1;
+
+        $dashboardManager->expects($this->any())->method('findOneBy')->will($this->returnValue(null));
+        $manager = $this->createManager($dashboardManager, $this->blockInteractor);
+
+        $this->setExpectedException('\Sonata\DashboardBundle\Exception\DashboardNotFoundException');
+        $manager->getDashboard($dashboard);
+    }
+
+    /**
+     * Test get Dashboard method without param return Dashboard.
+     */
+    public function testGetDashboardWithoutParam()
+    {
+        $dashboardManager = $this->getMock('Sonata\DashboardBundle\Model\DashboardManagerInterface');
+
+        $dashboardManager->expects($this->any())->method('findOneBy')->will($this->returnValue(new Dashboard()));
+        $this->blockInteractor->expects($this->any())->method('loadDashboardBlocks')->will($this->returnValue(array()));
+
+        $manager = $this->createManager($dashboardManager, $this->blockInteractor);
+        $manager->setCurrentDashboard(new Dashboard());
+        $dashboard = null;
+
+        $this->assertInstanceOf('Sonata\DashboardBundle\Model\DashboardInterface', $manager->getDashboard($dashboard));
+    }
+
+    /**
+     * Test get Dashboard method without param throw Exception.
+     */
+    public function testGetDashboardWithoutParamException()
+    {
+        $dashboardManager = $this->getMock('Sonata\DashboardBundle\Model\DashboardManagerInterface');
+
+        $this->blockInteractor->expects($this->any())->method('loadDashboardBlocks')->will($this->returnValue(array()));
+
+        $manager = $this->createManager($dashboardManager, $this->blockInteractor);
+
+        $dashboard = null;
+
+        $dashboardManager->expects($this->any())->method('findOneBy')->will($this->returnValue(null));
+        $manager = $this->createManager($dashboardManager, $this->blockInteractor);
+
+        $this->setExpectedException('\Sonata\DashboardBundle\Exception\DashboardNotFoundException');
+        $manager->getDashboard($dashboard);
+    }
+
+    /**
+     * Returns a mock block interactor.
+     *
+     * @return BlockInteractorInterface
+     */
+    private function getMockBlockInteractor()
+    {
+        $callback = function ($options) {
+            $block = new CmsBlock();
+            $block->setSettings($options);
+
+            return $block;
+        };
+
+        $mock = $this->getMock('Sonata\DashboardBundle\Model\BlockInteractorInterface');
+        $mock->expects($this->any())->method('createNewContainer')->will($this->returnCallback($callback));
+
+        return $mock;
+    }
+
+    /**
+     * Returns a cms dashboard manager.
+     *
+     * @return CmsDashboardManager
+     */
+    private function createManager($dashboardManager, $blockInteractor)
+    {
+        return new CmsDashboardManager($dashboardManager, $blockInteractor);
+    }
+}

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -37,7 +37,8 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'default_container' => 'sonata.dashboard.block.container',
             'templates' => array(
                 'compose' => 'MyBundle:MyController:my_template.html.twig',
-                'compose_container_show' => 'SonataDashboardBundle:DashboardAdmin:compose_container_show.html.twig',                            
+                'compose_container_show' => 'SonataDashboardBundle:DashboardAdmin:compose_container_show.html.twig',
+                'render' => 'SonataDashboardBundle:DashboardAdmin:render.html.twig',
             ),
         );
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -37,7 +37,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'default_container' => 'sonata.dashboard.block.container',
             'templates' => array(
                 'compose' => 'MyBundle:MyController:my_template.html.twig',
-                'compose_container_show' => 'SonataDashboardBundle:DashboardAdmin:compose_container_show.html.twig',
+                'compose_container_show' => 'SonataDashboardBundle:DashboardAdmin:compose_container_show.html.twig',                            
             ),
         );
 

--- a/Tests/Fixtures/Entity/CmsBlock.php
+++ b/Tests/Fixtures/Entity/CmsBlock.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Sonata\DashboardBundle\Tests\Fixtures\Entity;
+
+use Sonata\DashboardBundle\Model\Block as AbstractBlock;
+
+final class CmsBlock extends AbstractBlock
+{
+    public function setId($id)
+    {
+    }
+
+    public function getId()
+    {
+    }
+}

--- a/Tests/Twig/GlobalVariablesTest.php
+++ b/Tests/Twig/GlobalVariablesTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DashboardBundle\Tests\Twig;
+
+use Sonata\DashboardBundle\Twig\GlobalVariables;
+
+/**
+ * GlobalVariables.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+final class GlobalVariablesTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var CmsManagerSelector
+     */
+    private $cmsManagerSelector;
+
+    /**
+     * @var GlobalVariables
+     */
+    private $globals;
+
+    public function setUp()
+    {
+        $this->cmsManagerSelector = $this->getMockCmsManagerSelector();
+        $this->globals = new GlobalVariables($this->cmsManagerSelector);
+    }
+
+    /**
+     * @return CmsManagerInterface
+     */
+    public function testGetCmsManager()
+    {
+        $this->assertInstanceOf('Sonata\DashboardBundle\CmsManager\CmsManagerInterface', $this->globals->getCmsManager());
+    }
+
+    /**
+     * @return bool
+     */
+    public function testIsEditor()
+    {
+        $this->assertTrue($this->globals->isEditor());
+    }
+
+    /**
+     * Returns a cms manager selector.
+     *
+     * @return CmsManagerSelectorInterface
+     */
+    private function getMockCmsManagerSelector()
+    {
+        $cms = $this->getMock('Sonata\DashboardBundle\CmsManager\CmsManagerSelectorInterface');
+
+        $mock = $this->getMock('Sonata\DashboardBundle\CmsManager\CmsManagerInterface');
+        $cms->expects($this->any())->method('retrieve')->willReturn($mock);
+        $cms->expects($this->any())->method('isEditor')->willReturn(true);
+
+        return $cms;
+    }
+}

--- a/Twig/Extension/DashboardExtension.php
+++ b/Twig/Extension/DashboardExtension.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of sonata-project.
+ *
+ * (c) 2010 Thomas Rabaix
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DashboardBundle\Twig\Extension;
+
+use Sonata\BlockBundle\Templating\Helper\BlockHelper;
+use Sonata\DashboardBundle\CmsManager\CmsManagerSelectorInterface;
+use Sonata\DashboardBundle\Exception\DashboardNotFoundException;
+use Sonata\DashboardBundle\Model\DashboardBlockInterface;
+use Sonata\DashboardBundle\Model\DashboardInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * DashboardExtension.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+class DashboardExtension extends \Twig_Extension implements \Twig_Extension_InitRuntimeInterface
+{
+    /**
+     * @var CmsManagerSelectorInterface
+     */
+    private $cmsManagerSelector;
+
+    /**
+     * @var BlockHelper
+     */
+    private $blockHelper;
+    
+    /**
+     * @var \Twig_Environment
+     */
+    private $environment;
+    
+    /**
+     * @var array
+     */
+    private $resources;
+
+    /**
+     * Constructor.
+     *
+     * @param CmsManagerSelectorInterface $cmsManagerSelector  A CMS manager selector
+     * @param BlockHelper                 $blockHelper         The Block Helper
+     */
+    public function __construct(CmsManagerSelectorInterface $cmsManagerSelector, BlockHelper $blockHelper)
+    {
+        $this->cmsManagerSelector  = $cmsManagerSelector;
+        $this->blockHelper         = $blockHelper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction('sonata_dashboard_render_container', array($this, 'renderContainer'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('sonata_dashboard_render_block', array($this, 'renderBlock'), array('is_safe' => array('html'))),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initRuntime(\Twig_Environment $environment)
+    {
+        $this->environment = $environment;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'sonata_dashboard';
+    }
+    
+    /**
+     * @param string $template
+     * @param array  $parameters
+     *
+     * @return string
+     */
+    private function render($template, array $parameters = array())
+    {
+        if (!isset($this->resources[$template])) {
+            $this->resources[$template] = $this->environment->loadTemplate($template);
+        }
+
+        return $this->resources[$template]->render($parameters);
+    }
+
+    /**
+     * @param string $name
+     * @param null   $dashboard
+     * @param array  $options
+     *
+     * @return Response
+     */
+    public function renderContainer($name, $dashboard = null, array $options = array())
+    {
+        $cms = $this->cmsManagerSelector->retrieve();
+
+        if (!$dashboard) {
+            return '';
+        }
+
+        $container = $cms->findContainer($name, $dashboard);
+
+        if (!$container) {
+            return '';
+        }
+
+        return $this->renderBlock($container, $options);
+    }
+
+    /**
+     * @param DashboardBlockInterface $block
+     * @param array                   $options
+     *
+     * @return string
+     */
+    public function renderBlock(DashboardBlockInterface $block, array $options = array())
+    {
+        if ($block->getEnabled() === false && !$this->cmsManagerSelector->isEditor()) {
+            return '';
+        }
+
+        // build the parameters array
+        $options = array_merge(array(
+            'use_cache'        => isset($options['use_cache']) ? $options['use_cache'] : true,
+            'extra_cache_keys' => array(),
+        ), $options);
+
+        return $this->blockHelper->render($block, $options);
+    }
+}

--- a/Twig/Extension/DashboardExtension.php
+++ b/Twig/Extension/DashboardExtension.php
@@ -1,9 +1,9 @@
 <?php
 
 /*
- * This file is part of sonata-project.
+ * This file is part of the Sonata Project package.
  *
- * (c) 2010 Thomas Rabaix
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,10 +13,7 @@ namespace Sonata\DashboardBundle\Twig\Extension;
 
 use Sonata\BlockBundle\Templating\Helper\BlockHelper;
 use Sonata\DashboardBundle\CmsManager\CmsManagerSelectorInterface;
-use Sonata\DashboardBundle\Exception\DashboardNotFoundException;
 use Sonata\DashboardBundle\Model\DashboardBlockInterface;
-use Sonata\DashboardBundle\Model\DashboardInterface;
-use Symfony\Component\Routing\RouterInterface;
 
 /**
  * DashboardExtension.
@@ -34,12 +31,12 @@ class DashboardExtension extends \Twig_Extension implements \Twig_Extension_Init
      * @var BlockHelper
      */
     private $blockHelper;
-    
+
     /**
      * @var \Twig_Environment
      */
     private $environment;
-    
+
     /**
      * @var array
      */
@@ -48,13 +45,13 @@ class DashboardExtension extends \Twig_Extension implements \Twig_Extension_Init
     /**
      * Constructor.
      *
-     * @param CmsManagerSelectorInterface $cmsManagerSelector  A CMS manager selector
-     * @param BlockHelper                 $blockHelper         The Block Helper
+     * @param CmsManagerSelectorInterface $cmsManagerSelector A CMS manager selector
+     * @param BlockHelper                 $blockHelper        The Block Helper
      */
     public function __construct(CmsManagerSelectorInterface $cmsManagerSelector, BlockHelper $blockHelper)
     {
-        $this->cmsManagerSelector  = $cmsManagerSelector;
-        $this->blockHelper         = $blockHelper;
+        $this->cmsManagerSelector = $cmsManagerSelector;
+        $this->blockHelper = $blockHelper;
     }
 
     /**
@@ -82,21 +79,6 @@ class DashboardExtension extends \Twig_Extension implements \Twig_Extension_Init
     public function getName()
     {
         return 'sonata_dashboard';
-    }
-    
-    /**
-     * @param string $template
-     * @param array  $parameters
-     *
-     * @return string
-     */
-    private function render($template, array $parameters = array())
-    {
-        if (!isset($this->resources[$template])) {
-            $this->resources[$template] = $this->environment->loadTemplate($template);
-        }
-
-        return $this->resources[$template]->render($parameters);
     }
 
     /**
@@ -137,10 +119,25 @@ class DashboardExtension extends \Twig_Extension implements \Twig_Extension_Init
 
         // build the parameters array
         $options = array_merge(array(
-            'use_cache'        => isset($options['use_cache']) ? $options['use_cache'] : true,
+            'use_cache' => isset($options['use_cache']) ? $options['use_cache'] : true,
             'extra_cache_keys' => array(),
         ), $options);
 
         return $this->blockHelper->render($block, $options);
+    }
+
+    /**
+     * @param string $template
+     * @param array  $parameters
+     *
+     * @return string
+     */
+    private function render($template, array $parameters = array())
+    {
+        if (!isset($this->resources[$template])) {
+            $this->resources[$template] = $this->environment->loadTemplate($template);
+        }
+
+        return $this->resources[$template]->render($parameters);
     }
 }

--- a/Twig/GlobalVariables.php
+++ b/Twig/GlobalVariables.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DashboardBundle\Twig;
+
+use Sonata\DashboardBundle\CmsManager\CmsManagerSelectorInterface;
+
+/**
+ * GlobalVariables.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+final class GlobalVariables
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $cmsManagerSelector;
+
+    /**
+     * @param CmsManagerSelector $cmsManagerSelector
+     */
+    public function __construct(CmsManagerSelectorInterface $cmsManagerSelector)
+    {
+        $this->cmsManagerSelector = $cmsManagerSelector;
+    }
+
+    /**
+     * @return CmsManagerInterface
+     */
+    public function getCmsManager()
+    {
+        return $this->cmsManagerSelector->retrieve();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEditor()
+    {
+        return $this->cmsManagerSelector->isEditor();
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Added
- Added Cms Manager
- Added Twig Extension
- Added Render in DashboardAdmin
- Added isDefault field in Dashboard
- Added Event Listener on isDefault (SonataAdmin)
- Added Dashboard selector in render view
```
## To do
- [ ] Update documentation (explain "user composed" dashboard for backend)
- [ ] add render (composer ?) template for "user composed" dashboard for frontend ?
## Subject

Added CmsDashboardManager (same spirit as CmsPageManager in SonataPageBundle)

The CmsDashboardManager class is in charge of retrieving the dashboard with all its associated blocks

Added Twig Extension to allow using {{ sonata_dashboard_render_xx }} in twig templates and used it to add renderAction in DashboardAdmin to view result of composer

Added isDefault for Dashboard to replace SonataAdmin dashboard (config defined) by default one if exists and is enabled
