### PR TITLE
Fixed wrong imports in tests

### DIFF
--- a/Tests/Block/ContainerBlockServiceTest.php
+++ b/Tests/Block/ContainerBlockServiceTest.php
@@ -13,21 +13,20 @@ namespace Sonata\DashboardBundle\Tests\Block;
 
 use Sonata\BlockBundle\Block\BlockContext;
 use Sonata\BlockBundle\Model\Block;
-use Sonata\BlockBundle\Tests\Block\Service\FakeTemplating;
+use Sonata\BlockBundle\Test\AbstractBlockServiceTestCase;
 use Sonata\DashboardBundle\Block\ContainerBlockService;
 
 /**
  * Test Container Block service.
  */
-class ContainerBlockServiceTest extends \PHPUnit_Framework_TestCase
+class ContainerBlockServiceTest extends AbstractBlockServiceTestCase
 {
     /**
      * test the block execute() method.
      */
     public function testExecute()
     {
-        $templating = new FakeTemplating();
-        $service = new ContainerBlockService('core.container', $templating);
+        $service = new ContainerBlockService('core.container', $this->templating);
 
         $block = new Block();
         $block->setName('block.name');
@@ -45,10 +44,10 @@ class ContainerBlockServiceTest extends \PHPUnit_Framework_TestCase
 
         $service->execute($blockContext);
 
-        $this->assertEquals('SonataDashboardBundle:BlockAdmin:block_container.html.twig', $templating->view);
-        $this->assertEquals('block.code', $templating->parameters['block']->getSetting('code'));
-        $this->assertEquals('block.name', $templating->parameters['block']->getName());
-        $this->assertInstanceOf('Sonata\BlockBundle\Model\Block', $templating->parameters['block']);
+        $this->assertEquals('SonataDashboardBundle:BlockAdmin:block_container.html.twig', $this->templating->view);
+        $this->assertEquals('block.code', $this->templating->parameters['block']->getSetting('code'));
+        $this->assertEquals('block.name', $this->templating->parameters['block']->getName());
+        $this->assertInstanceOf('Sonata\BlockBundle\Model\Block', $this->templating->parameters['block']);
     }
 
     /**
@@ -56,8 +55,7 @@ class ContainerBlockServiceTest extends \PHPUnit_Framework_TestCase
      */
     public function testLayout()
     {
-        $templating = new FakeTemplating();
-        $service = new ContainerBlockService('core.container', $templating);
+        $service = new ContainerBlockService('core.container', $this->templating);
 
         $block = new Block();
         $block->setName('block.name');
@@ -73,11 +71,11 @@ class ContainerBlockServiceTest extends \PHPUnit_Framework_TestCase
 
         $service->execute($blockContext);
 
-        $this->assertInternalType('array', $templating->parameters['decorator']);
-        $this->assertArrayHasKey('pre', $templating->parameters['decorator']);
-        $this->assertArrayHasKey('post', $templating->parameters['decorator']);
-        $this->assertEquals('before', $templating->parameters['decorator']['pre']);
-        $this->assertEquals('after', $templating->parameters['decorator']['post']);
+        $this->assertInternalType('array', $this->templating->parameters['decorator']);
+        $this->assertArrayHasKey('pre', $this->templating->parameters['decorator']);
+        $this->assertArrayHasKey('post', $this->templating->parameters['decorator']);
+        $this->assertEquals('before', $this->templating->parameters['decorator']['pre']);
+        $this->assertEquals('after', $this->templating->parameters['decorator']['post']);
     }
 
     /**
@@ -85,8 +83,7 @@ class ContainerBlockServiceTest extends \PHPUnit_Framework_TestCase
      */
     public function testFormBuilder()
     {
-        $templating = new FakeTemplating();
-        $service = new ContainerBlockService('core.container', $templating);
+        $service = new ContainerBlockService('core.container', $this->templating);
 
         $block = new Block();
         $block->setName('block.name');

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^5.3 || ^7.0",
         "sonata-project/admin-bundle": "^3.0",
-        "sonata-project/block-bundle": "^3.0",
+        "sonata-project/block-bundle": "^3.1.1",
         "sonata-project/cache-bundle": "^2.1.7",
         "sonata-project/core-bundle": "^3.0",
         "sonata-project/datagrid-bundle": "^2.2",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a fix for the unit tests in the stable branch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- unit tests use the correct namespace in imports.
```

## Subject

This fixes the imports in the test cases. The sub namespace `Tests` isn't public anymore.

