### PR TITLE
Removed duplicate translations

### DIFF
--- a/Admin/BlockAdmin.php
+++ b/Admin/BlockAdmin.php
@@ -327,7 +327,7 @@ class BlockAdmin extends Admin
             $optionsGroupOptions['name'] = '';
         }
 
-        $formMapper->with($this->trans('form.field_group_general'), $generalGroupOptions);
+        $formMapper->with('form.field_group_general', $generalGroupOptions);
 
         $containerBlockTypes = $this->containerBlockTypes;
         $isContainerRoot = $block && in_array($block->getType(), $containerBlockTypes) && !$this->hasParentFieldDescription();
@@ -342,7 +342,7 @@ class BlockAdmin extends Admin
         $formMapper->end();
 
         if ($isContainerRoot || $isStandardBlock) {
-            $formMapper->with($this->trans('form.field_group_general'), $generalGroupOptions);
+            $formMapper->with('form.field_group_general', $generalGroupOptions);
 
             $service = $this->blockManager->get($block);
 
@@ -375,7 +375,7 @@ class BlockAdmin extends Admin
 
             $formMapper->end();
 
-            $formMapper->with($this->trans('form.field_group_options'), $optionsGroupOptions);
+            $formMapper->with('form.field_group_options', $optionsGroupOptions);
 
             if ($block->getId() > 0) {
                 $service->buildEditForm($formMapper, $block);
@@ -398,7 +398,7 @@ class BlockAdmin extends Admin
             $formMapper->end();
         } else {
             $formMapper
-                ->with($this->trans('form.field_group_options'), $optionsGroupOptions)
+                ->with('form.field_group_options', $optionsGroupOptions)
                     ->add('type', 'sonata_block_service_choice', array(
                         'context' => 'sonata_dashboard_bundle',
                     ))

--- a/Admin/DashboardAdmin.php
+++ b/Admin/DashboardAdmin.php
@@ -131,18 +131,15 @@ class DashboardAdmin extends Admin
 
         $id = $admin->getRequest()->get('id');
 
-        $menu->addChild(
-            $this->trans('sidemenu.link_edit_dashboard'),
+        $menu->addChild('sidemenu.link_edit_dashboard',
             array('uri' => $admin->generateUrl('edit', array('id' => $id)))
         );
 
-        $menu->addChild(
-            $this->trans('sidemenu.link_compose_dashboard'),
+        $menu->addChild('sidemenu.link_compose_dashboard',
             array('uri' => $admin->generateUrl('compose', array('id' => $id)))
         );
 
-        $menu->addChild(
-            $this->trans('sidemenu.link_list_blocks'),
+        $menu->addChild('sidemenu.link_list_blocks',
             array('uri' => $admin->generateUrl('sonata.dashboard.admin.dashboard|sonata.dashboard.admin.block.list', array('id' => $id)))
         );
     }

--- a/Admin/DashboardAdmin.php
+++ b/Admin/DashboardAdmin.php
@@ -103,11 +103,11 @@ class DashboardAdmin extends Admin
     {
         // define group zoning
         $formMapper
-            ->with($this->trans('form_dashboard.group_main_label'), array('class' => 'col-md-12'))->end()
+            ->with('form_dashboard.group_main_label', array('class' => 'col-md-12'))->end()
         ;
 
         $formMapper
-            ->with($this->trans('form_dashboard.group_main_label'))
+            ->with('form_dashboard.group_main_label')
                 ->add('name')
                 ->add('enabled', null, array('required' => false))
             ->end()

--- a/Admin/DashboardAdmin.php
+++ b/Admin/DashboardAdmin.php
@@ -114,7 +114,7 @@ class DashboardAdmin extends Admin
         ;
 
         $formMapper->setHelps(array(
-            'name' => $this->trans('help_dashboard_name'),
+            'name' => 'help_dashboard_name',
         ));
     }
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^5.3 || ^7.0",
-        "sonata-project/admin-bundle": "^3.0",
+        "sonata-project/admin-bundle": "^3.4",
         "sonata-project/block-bundle": "^3.1.1",
         "sonata-project/cache-bundle": "^2.1.7",
         "sonata-project/core-bundle": "^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - master is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDashboardBundle/blob/master/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because there is no other branch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Removed duplicate tramslation of form groups
- Fixed duplicate translation in tab menu
- Fixed duplicate translation of form help
```

## Subject

Since the 3.4 release of the admin bundle, the menu items are translated in the twig templates by the knp menu bundle.
