### PR TITLE
Remove usage of deprecated Admin class

### DIFF
--- a/Admin/BlockAdmin.php
+++ b/Admin/BlockAdmin.php
@@ -12,7 +12,7 @@
 namespace Sonata\DashboardBundle\Admin;
 
 use Doctrine\ORM\EntityRepository;
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
@@ -29,7 +29,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class BlockAdmin extends Admin
+class BlockAdmin extends AbstractAdmin
 {
     /**
      * @var BlockServiceManagerInterface

--- a/Admin/DashboardAdmin.php
+++ b/Admin/DashboardAdmin.php
@@ -12,7 +12,7 @@
 namespace Sonata\DashboardBundle\Admin;
 
 use Knp\Menu\ItemInterface as MenuItemInterface;
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -25,7 +25,7 @@ use Sonata\AdminBundle\Show\ShowMapper;
  *
  * @author Quentin Somazzi <qsomazzi@ekino.com>
  */
-class DashboardAdmin extends Admin
+class DashboardAdmin extends AbstractAdmin
 {
     protected $accessMapping = array(
         'compose' => 'EDIT',

--- a/Tests/Admin/BlockAdminTest.php
+++ b/Tests/Admin/BlockAdminTest.php
@@ -11,7 +11,6 @@
 
 namespace Sonata\DashboardBundle\Tests\Admin;
 
-use Sonata\AdminBundle\Admin\Admin;
 use Sonata\DashboardBundle\Admin\BlockAdmin;
 use Sonata\DashboardBundle\Tests\Fixtures\Entity\FooGetName;
 use Sonata\DashboardBundle\Tests\Fixtures\Entity\FooGetNameNull;


### PR DESCRIPTION
I am targetting this branch, because this is backward compatible.

## Changelog

```markdown
### Changed
- Changed `BlockAdmin` and `DashboardAdmin` extends to use recommended `AbstractAdmin` class.
```

## Subject

This replace usage of deprecated ``Admin`` class with ``AbstractAdmin``.

