### PR TITLE
Fixed paths related to SonataEasyExtendsBundle

### DIFF
--- a/Resources/config/doctrine/Block.orm.xml.skeleton
+++ b/Resources/config/doctrine/Block.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\DashboardBundle\Entity\Block"
+        name="{{ namespace }}\Entity\Block"
         table="dashboard__block"
         repository-class="Doctrine\ORM\EntityRepository">
 

--- a/Resources/config/doctrine/Dashboard.orm.xml.skeleton
+++ b/Resources/config/doctrine/Dashboard.orm.xml.skeleton
@@ -9,7 +9,7 @@
             association mapping  : http://www.doctrine-project.org/projects/orm/2.0/docs/reference/association-mapping/en
     -->
     <entity
-        name="Application\Sonata\DashboardBundle\Entity\Dashboard"
+        name="{{ namespace }}\Entity\Dashboard"
         table="dashboard__dashboard"
         >
 

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "sonata-project/core-bundle": "^3.0",
         "sonata-project/datagrid-bundle": "^2.2",
         "sonata-project/doctrine-extensions": "^1.0",
+        "sonata-project/easy-extends-bundle": "^2.2",
         "sonata-project/notification-bundle": "^3.0",
         "symfony/config": "^2.3 || ^3.0",
         "symfony/dependency-injection": "^2.3 || ^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDashboardBundle/blob/master/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because my patch is fixing the bug, arisen due to the hardcoded class-path.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed hardcoded paths to classes in `.xml.skeleton` files of config
```

## Subject

<!-- Describe your Pull Request content here -->
Fixed some hardcoded paths, which become invalid after enabling
the '--namespace' option in SonataEasyExtendsBundle's last release
(https://github.com/sonata-project/SonataEasyExtendsBundle/releases/tag/2.2.0)

See also: https://github.com/sonata-project/SonataMediaBundle/pull/1250