### PR TITLE
Drop outdated versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^5.6 || ^7.1",
         "sonata-project/admin-bundle": "^3.4",
         "sonata-project/block-bundle": "^3.1.1",
         "sonata-project/cache-bundle": "^2.1.7",

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,11 @@
         "sonata-project/doctrine-extensions": "^1.0",
         "sonata-project/easy-extends-bundle": "^2.2",
         "sonata-project/notification-bundle": "^3.0",
-        "symfony/config": "^2.3 || ^3.0",
-        "symfony/dependency-injection": "^2.3 || ^3.0",
-        "symfony/http-kernel": "^2.3 || ^3.0",
-        "symfony/options-resolver": "^2.3 || ^3.0",
-        "symfony/security-core": "^2.3 || ^3.0"
+        "symfony/config": "^2.8 || ^3.1",
+        "symfony/dependency-injection": "^2.8 || ^3.1",
+        "symfony/http-kernel": "^2.8 || ^3.1",
+        "symfony/options-resolver": "^2.8 || ^3.1",
+        "symfony/security-core": "^2.8 || ^3.1"
     },
     "require-dev": {
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - master is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDashboardBundle/blob/master/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because there is no stable branch and we are working on the 0.x version.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
 - Removed support for PHP 5
 - Removed support for symfony <2.8 and 3.0
```


## Subject

We should take a step forward and drop old version before release the first (stable) version for this bundle.
