### PR TITLE
Added missing translation keys

### DIFF
--- a/Resources/translations/SonataDashboardBundle.bg.xliff
+++ b/Resources/translations/SonataDashboardBundle.bg.xliff
@@ -214,6 +214,42 @@
                 <source>form.label_template</source>
                 <target>form.label_template</target>
             </trans-unit>
+            <trans-unit id="53" resname="filter.label_enabled">
+                <source>filter.label_enabled</source>
+                <target>filter.label_enabled</target>
+            </trans-unit>
+            <trans-unit id="54" resname="filter.label_name">
+                <source>filter.label_name</source>
+                <target>filter.label_name</target>
+            </trans-unit>
+            <trans-unit id="55" resname="filter.label_edited">
+                <source>filter.label_edited</source>
+                <target>filter.label_edited</target>
+            </trans-unit>
+            <trans-unit id="56" resname="filter.label_type">
+                <source>filter.label_type</source>
+                <target>filter.label_type</target>
+            </trans-unit>
+            <trans-unit id="57" resname="breadcrumb.link_block_create">
+                <source>breadcrumb.link_block_create</source>
+                <target>breadcrumb.link_block_create</target>
+            </trans-unit>
+            <trans-unit id="58" resname="title_select_block_type">
+                <source>title_select_block_type</source>
+                <target>title_select_block_type</target>
+            </trans-unit>
+            <trans-unit id="59" resname="show.label_enabled">
+                <source>show.label_enabled</source>
+                <target>show.label_enabled</target>
+            </trans-unit>
+            <trans-unit id="60" resname="show.label_name">
+                <source>show.label_name</source>
+                <target>show.label_name</target>
+            </trans-unit>
+            <trans-unit id="61" resname="show.label_edited">
+                <source>show.label_edited</source>
+                <target>show.label_edited</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataDashboardBundle.de.xliff
+++ b/Resources/translations/SonataDashboardBundle.de.xliff
@@ -214,6 +214,42 @@
                 <source>form.label_template</source>
                 <target>Template</target>
             </trans-unit>
+            <trans-unit id="53" resname="filter.label_enabled">
+                <source>filter.label_enabled</source>
+                <target>Aktiviert</target>
+            </trans-unit>
+            <trans-unit id="54" resname="filter.label_name">
+                <source>filter.label_name</source>
+                <target>Name</target>
+            </trans-unit>
+            <trans-unit id="55" resname="filter.label_edited">
+                <source>filter.label_edited</source>
+                <target>Bearbeitet</target>
+            </trans-unit>
+            <trans-unit id="56" resname="filter.label_type">
+                <source>filter.label_type</source>
+                <target>Typ</target>
+            </trans-unit>
+            <trans-unit id="57" resname="breadcrumb.link_block_create">
+                <source>breadcrumb.link_block_create</source>
+                <target>Erzeugen</target>
+            </trans-unit>
+            <trans-unit id="58" resname="title_select_block_type">
+                <source>title_select_block_type</source>
+                <target>Wähle einen Block-Typ</target>
+            </trans-unit>
+            <trans-unit id="59" resname="show.label_enabled">
+                <source>show.label_enabled</source>
+                <target>Aktiviert</target>
+            </trans-unit>
+            <trans-unit id="60" resname="show.label_name">
+                <source>show.label_name</source>
+                <target>Name</target>
+            </trans-unit>
+            <trans-unit id="61" resname="show.label_edited">
+                <source>show.label_edited</source>
+                <target>Bearbeitet</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataDashboardBundle.en.xliff
+++ b/Resources/translations/SonataDashboardBundle.en.xliff
@@ -214,6 +214,42 @@
                 <source>form.label_template</source>
                 <target>Template</target>
             </trans-unit>
+            <trans-unit id="53" resname="filter.label_enabled">
+                <source>filter.label_enabled</source>
+                <target>Enabled</target>
+            </trans-unit>
+            <trans-unit id="54" resname="filter.label_name">
+                <source>filter.label_name</source>
+                <target>Name</target>
+            </trans-unit>
+            <trans-unit id="55" resname="filter.label_edited">
+                <source>filter.label_edited</source>
+                <target>Edited</target>
+            </trans-unit>
+            <trans-unit id="56" resname="filter.label_type">
+                <source>filter.label_type</source>
+                <target>Type</target>
+            </trans-unit>
+            <trans-unit id="57" resname="breadcrumb.link_block_create">
+                <source>breadcrumb.link_block_create</source>
+                <target>Create</target>
+            </trans-unit>
+            <trans-unit id="58" resname="title_select_block_type">
+                <source>title_select_block_type</source>
+                <target>Select a block type</target>
+            </trans-unit>
+            <trans-unit id="59" resname="show.label_enabled">
+                <source>show.label_enabled</source>
+                <target>Enabled</target>
+            </trans-unit>
+            <trans-unit id="60" resname="show.label_name">
+                <source>show.label_name</source>
+                <target>Name</target>
+            </trans-unit>
+            <trans-unit id="61" resname="show.label_edited">
+                <source>show.label_edited</source>
+                <target>Edited</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataDashboardBundle.es.xliff
+++ b/Resources/translations/SonataDashboardBundle.es.xliff
@@ -214,6 +214,42 @@
                 <source>form.label_template</source>
                 <target>form.label_template</target>
             </trans-unit>
+            <trans-unit id="53" resname="filter.label_enabled">
+                <source>filter.label_enabled</source>
+                <target>filter.label_enabled</target>
+            </trans-unit>
+            <trans-unit id="54" resname="filter.label_name">
+                <source>filter.label_name</source>
+                <target>filter.label_name</target>
+            </trans-unit>
+            <trans-unit id="55" resname="filter.label_edited">
+                <source>filter.label_edited</source>
+                <target>filter.label_edited</target>
+            </trans-unit>
+            <trans-unit id="56" resname="filter.label_type">
+                <source>filter.label_type</source>
+                <target>filter.label_type</target>
+            </trans-unit>
+            <trans-unit id="57" resname="breadcrumb.link_block_create">
+                <source>breadcrumb.link_block_create</source>
+                <target>breadcrumb.link_block_create</target>
+            </trans-unit>
+            <trans-unit id="58" resname="title_select_block_type">
+                <source>title_select_block_type</source>
+                <target>title_select_block_type</target>
+            </trans-unit>
+            <trans-unit id="59" resname="show.label_enabled">
+                <source>show.label_enabled</source>
+                <target>show.label_enabled</target>
+            </trans-unit>
+            <trans-unit id="60" resname="show.label_name">
+                <source>show.label_name</source>
+                <target>show.label_name</target>
+            </trans-unit>
+            <trans-unit id="61" resname="show.label_edited">
+                <source>show.label_edited</source>
+                <target>show.label_edited</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataDashboardBundle.ja.xliff
+++ b/Resources/translations/SonataDashboardBundle.ja.xliff
@@ -214,6 +214,42 @@
                 <source>form.label_template</source>
                 <target>form.label_template</target>
             </trans-unit>
+            <trans-unit id="53" resname="filter.label_enabled">
+                <source>filter.label_enabled</source>
+                <target>filter.label_enabled</target>
+            </trans-unit>
+            <trans-unit id="54" resname="filter.label_name">
+                <source>filter.label_name</source>
+                <target>filter.label_name</target>
+            </trans-unit>
+            <trans-unit id="55" resname="filter.label_edited">
+                <source>filter.label_edited</source>
+                <target>filter.label_edited</target>
+            </trans-unit>
+            <trans-unit id="56" resname="filter.label_type">
+                <source>filter.label_type</source>
+                <target>filter.label_type</target>
+            </trans-unit>
+            <trans-unit id="57" resname="breadcrumb.link_block_create">
+                <source>breadcrumb.link_block_create</source>
+                <target>breadcrumb.link_block_create</target>
+            </trans-unit>
+            <trans-unit id="58" resname="title_select_block_type">
+                <source>title_select_block_type</source>
+                <target>title_select_block_type</target>
+            </trans-unit>
+            <trans-unit id="59" resname="show.label_enabled">
+                <source>show.label_enabled</source>
+                <target>show.label_enabled</target>
+            </trans-unit>
+            <trans-unit id="60" resname="show.label_name">
+                <source>show.label_name</source>
+                <target>show.label_name</target>
+            </trans-unit>
+            <trans-unit id="61" resname="show.label_edited">
+                <source>show.label_edited</source>
+                <target>show.label_edited</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataDashboardBundle.nl.xliff
+++ b/Resources/translations/SonataDashboardBundle.nl.xliff
@@ -214,6 +214,42 @@
                 <source>form.label_template</source>
                 <target>form.label_template</target>
             </trans-unit>
+            <trans-unit id="53" resname="filter.label_enabled">
+                <source>filter.label_enabled</source>
+                <target>filter.label_enabled</target>
+            </trans-unit>
+            <trans-unit id="54" resname="filter.label_name">
+                <source>filter.label_name</source>
+                <target>filter.label_name</target>
+            </trans-unit>
+            <trans-unit id="55" resname="filter.label_edited">
+                <source>filter.label_edited</source>
+                <target>filter.label_edited</target>
+            </trans-unit>
+            <trans-unit id="56" resname="filter.label_type">
+                <source>filter.label_type</source>
+                <target>filter.label_type</target>
+            </trans-unit>
+            <trans-unit id="57" resname="breadcrumb.link_block_create">
+                <source>breadcrumb.link_block_create</source>
+                <target>breadcrumb.link_block_create</target>
+            </trans-unit>
+            <trans-unit id="58" resname="title_select_block_type">
+                <source>title_select_block_type</source>
+                <target>title_select_block_type</target>
+            </trans-unit>
+            <trans-unit id="59" resname="show.label_enabled">
+                <source>show.label_enabled</source>
+                <target>show.label_enabled</target>
+            </trans-unit>
+            <trans-unit id="60" resname="show.label_name">
+                <source>show.label_name</source>
+                <target>show.label_name</target>
+            </trans-unit>
+            <trans-unit id="61" resname="show.label_edited">
+                <source>show.label_edited</source>
+                <target>show.label_edited</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataDashboardBundle.pt_BR.xliff
+++ b/Resources/translations/SonataDashboardBundle.pt_BR.xliff
@@ -214,6 +214,42 @@
                 <source>form.label_template</source>
                 <target>form.label_template</target>
             </trans-unit>
+            <trans-unit id="53" resname="filter.label_enabled">
+                <source>filter.label_enabled</source>
+                <target>filter.label_enabled</target>
+            </trans-unit>
+            <trans-unit id="54" resname="filter.label_name">
+                <source>filter.label_name</source>
+                <target>filter.label_name</target>
+            </trans-unit>
+            <trans-unit id="55" resname="filter.label_edited">
+                <source>filter.label_edited</source>
+                <target>filter.label_edited</target>
+            </trans-unit>
+            <trans-unit id="56" resname="filter.label_type">
+                <source>filter.label_type</source>
+                <target>filter.label_type</target>
+            </trans-unit>
+            <trans-unit id="57" resname="breadcrumb.link_block_create">
+                <source>breadcrumb.link_block_create</source>
+                <target>breadcrumb.link_block_create</target>
+            </trans-unit>
+            <trans-unit id="58" resname="title_select_block_type">
+                <source>title_select_block_type</source>
+                <target>title_select_block_type</target>
+            </trans-unit>
+            <trans-unit id="59" resname="show.label_enabled">
+                <source>show.label_enabled</source>
+                <target>show.label_enabled</target>
+            </trans-unit>
+            <trans-unit id="60" resname="show.label_name">
+                <source>show.label_name</source>
+                <target>show.label_name</target>
+            </trans-unit>
+            <trans-unit id="61" resname="show.label_edited">
+                <source>show.label_edited</source>
+                <target>show.label_edited</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataDashboardBundle.sk.xliff
+++ b/Resources/translations/SonataDashboardBundle.sk.xliff
@@ -214,6 +214,42 @@
                 <source>form.label_template</source>
                 <target>form.label_template</target>
             </trans-unit>
+            <trans-unit id="53" resname="filter.label_enabled">
+                <source>filter.label_enabled</source>
+                <target>filter.label_enabled</target>
+            </trans-unit>
+            <trans-unit id="54" resname="filter.label_name">
+                <source>filter.label_name</source>
+                <target>filter.label_name</target>
+            </trans-unit>
+            <trans-unit id="55" resname="filter.label_edited">
+                <source>filter.label_edited</source>
+                <target>filter.label_edited</target>
+            </trans-unit>
+            <trans-unit id="56" resname="filter.label_type">
+                <source>filter.label_type</source>
+                <target>filter.label_type</target>
+            </trans-unit>
+            <trans-unit id="57" resname="breadcrumb.link_block_create">
+                <source>breadcrumb.link_block_create</source>
+                <target>breadcrumb.link_block_create</target>
+            </trans-unit>
+            <trans-unit id="58" resname="title_select_block_type">
+                <source>title_select_block_type</source>
+                <target>title_select_block_type</target>
+            </trans-unit>
+            <trans-unit id="59" resname="show.label_enabled">
+                <source>show.label_enabled</source>
+                <target>show.label_enabled</target>
+            </trans-unit>
+            <trans-unit id="60" resname="show.label_name">
+                <source>show.label_name</source>
+                <target>show.label_name</target>
+            </trans-unit>
+            <trans-unit id="61" resname="show.label_edited">
+                <source>show.label_edited</source>
+                <target>show.label_edited</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataDashboardBundle.sl.xliff
+++ b/Resources/translations/SonataDashboardBundle.sl.xliff
@@ -214,6 +214,42 @@
                 <source>form.label_template</source>
                 <target>form.label_template</target>
             </trans-unit>
+            <trans-unit id="53" resname="filter.label_enabled">
+                <source>filter.label_enabled</source>
+                <target>filter.label_enabled</target>
+            </trans-unit>
+            <trans-unit id="54" resname="filter.label_name">
+                <source>filter.label_name</source>
+                <target>filter.label_name</target>
+            </trans-unit>
+            <trans-unit id="55" resname="filter.label_edited">
+                <source>filter.label_edited</source>
+                <target>filter.label_edited</target>
+            </trans-unit>
+            <trans-unit id="56" resname="filter.label_type">
+                <source>filter.label_type</source>
+                <target>filter.label_type</target>
+            </trans-unit>
+            <trans-unit id="57" resname="breadcrumb.link_block_create">
+                <source>breadcrumb.link_block_create</source>
+                <target>breadcrumb.link_block_create</target>
+            </trans-unit>
+            <trans-unit id="58" resname="title_select_block_type">
+                <source>title_select_block_type</source>
+                <target>title_select_block_type</target>
+            </trans-unit>
+            <trans-unit id="59" resname="show.label_enabled">
+                <source>show.label_enabled</source>
+                <target>show.label_enabled</target>
+            </trans-unit>
+            <trans-unit id="60" resname="show.label_name">
+                <source>show.label_name</source>
+                <target>show.label_name</target>
+            </trans-unit>
+            <trans-unit id="61" resname="show.label_edited">
+                <source>show.label_edited</source>
+                <target>show.label_edited</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - master is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDashboardBundle/blob/master/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is the only branch.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added missing translation keys
```

## Subject

These keys only exists in the French translation.
