### PR TITLE
Removed deprecated calls

### DIFF
--- a/Admin/BlockAdmin.php
+++ b/Admin/BlockAdmin.php
@@ -336,7 +336,7 @@ class BlockAdmin extends AbstractAdmin
         if (!$isComposer) {
             $formMapper->add('name');
         } elseif (!$isContainerRoot) {
-            $formMapper->add('name', 'hidden');
+            $formMapper->add('name', 'Symfony\Component\Form\Extension\Core\Type\HiddenType');
         }
 
         $formMapper->end();
@@ -348,7 +348,7 @@ class BlockAdmin extends AbstractAdmin
 
             // need to investigate on this case where $dashboard == null ... this should not be possible
             if ($isStandardBlock && $dashboard && !empty($containerBlockTypes)) {
-                $formMapper->add('parent', 'entity', array(
+                $formMapper->add('parent', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', array(
                     'class' => $this->getClass(),
                     'query_builder' => function (EntityRepository $repository) use ($dashboard, $containerBlockTypes) {
                         return $repository->createQueryBuilder('a')
@@ -364,13 +364,15 @@ class BlockAdmin extends AbstractAdmin
             }
 
             if ($isComposer) {
-                $formMapper->add('enabled', 'hidden', array('data' => true));
+                $formMapper->add('enabled', 'Symfony\Component\Form\Extension\Core\Type\HiddenType', array(
+                    'data' => true,
+                ));
             } else {
                 $formMapper->add('enabled');
             }
 
             if ($isStandardBlock) {
-                $formMapper->add('position', 'integer');
+                $formMapper->add('position', 'Symfony\Component\Form\Extension\Core\Type\IntegerType');
             }
 
             $formMapper->end();
@@ -386,7 +388,9 @@ class BlockAdmin extends AbstractAdmin
             // When editing a container in composer view, hide some settings
             if ($isContainerRoot && $isComposer) {
                 $formMapper->remove('children');
-                $formMapper->add('name', 'text', array('required' => true));
+                $formMapper->add('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
+                    'required' => true,
+                ));
 
                 $formSettings = $formMapper->get('settings');
 
@@ -399,11 +403,11 @@ class BlockAdmin extends AbstractAdmin
         } else {
             $formMapper
                 ->with('form.field_group_options', $optionsGroupOptions)
-                    ->add('type', 'sonata_block_service_choice', array(
+                    ->add('type', 'Sonata\BlockBundle\Form\Type\ServiceListType', array(
                         'context' => 'sonata_dashboard_bundle',
                     ))
                     ->add('enabled')
-                    ->add('position', 'integer')
+                    ->add('position', 'Symfony\Component\Form\Extension\Core\Type\IntegerType')
                 ->end()
             ;
         }

--- a/Block/ContainerBlockService.php
+++ b/Block/ContainerBlockService.php
@@ -32,18 +32,18 @@ class ContainerBlockService extends BaseContainerBlockService
 
         $formMapper->add('settings', 'sonata_type_immutable_array', array(
             'keys' => array(
-                array('code', 'text', array(
+                array('code', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
                     'required' => false,
                     'label' => 'form.label_code',
                 )),
-                array('layout', 'textarea', array(
+                array('layout', 'Symfony\Component\Form\Extension\Core\Type\TextareaType', array(
                     'label' => 'form.label_layout',
                 )),
-                array('class', 'text', array(
+                array('class', 'Symfony\Component\Form\Extension\Core\Type\TextType', array(
                     'required' => false,
                     'label' => 'form.label_class',
                 )),
-                array('template', 'sonata_type_container_template_choice', array(
+                array('template', 'Sonata\BlockBundle\Form\Type\ContainerTemplateType', array(
                     'label' => 'form.label_template',
                 )),
             ),


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

Removed some more deprecated calls. We don't have symfony 2.3 support, so we can use the *new* class names instead of form type aliases.
