### PR TITLE
Dropped PHP 5 support

### DIFF
--- a/DependencyInjection/SonataDashboardExtension.php
+++ b/DependencyInjection/SonataDashboardExtension.php
@@ -153,25 +153,4 @@ class SonataDashboardExtension extends Extension
             'orphanRemoval' => false,
         ]);
     }
-
-    /**
-     * Add class to compile.
-     */
-    public function configureClassesToCompile()
-    {
-        $this->addClassesToCompile([
-            'Sonata\\DashboardBundle\\Block\\ContainerBlockService',
-            'Sonata\\DashboardBundle\\Entity\\BaseBlock',
-            'Sonata\\DashboardBundle\\Entity\\BaseDashboard',
-            'Sonata\\DashboardBundle\\Entity\\BlockInteractor',
-            'Sonata\\DashboardBundle\\Entity\\BlockManager',
-            'Sonata\\DashboardBundle\\Entity\\DashboardManager',
-            'Sonata\\DashboardBundle\\Model\\Block',
-            'Sonata\\DashboardBundle\\Model\\BlockInteractorInterface',
-            'Sonata\\DashboardBundle\\Model\\Dashboard',
-            'Sonata\\DashboardBundle\\Model\\DashboardBlockInterface',
-            'Sonata\\DashboardBundle\\Model\\DashboardInterface',
-            'Sonata\\DashboardBundle\\Model\\DashboardManagerInterface',
-        ]);
-    }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.1",
+        "php": "^7.1",
         "sonata-project/admin-bundle": "^3.4",
         "sonata-project/block-bundle": "^3.1.1",
         "sonata-project/cache-bundle": "^2.1.7",


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Removed
- Support for old versions of php
- classes to compile
```
