### PR TITLE
Removed form type aliases

### DIFF
--- a/Admin/BlockAdmin.php
+++ b/Admin/BlockAdmin.php
@@ -18,9 +18,14 @@ use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\BlockBundle\Block\BlockServiceManagerInterface;
+use Sonata\BlockBundle\Form\Type\ServiceListType;
 use Sonata\Cache\CacheManagerInterface;
 use Sonata\DashboardBundle\Entity\BaseBlock;
 use Sonata\DashboardBundle\Model\DashboardInterface;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -336,7 +341,7 @@ class BlockAdmin extends AbstractAdmin
         if (!$isComposer) {
             $formMapper->add('name');
         } elseif (!$isContainerRoot) {
-            $formMapper->add('name', 'Symfony\Component\Form\Extension\Core\Type\HiddenType');
+            $formMapper->add('name', HiddenType::class);
         }
 
         $formMapper->end();
@@ -348,7 +353,7 @@ class BlockAdmin extends AbstractAdmin
 
             // need to investigate on this case where $dashboard == null ... this should not be possible
             if ($isStandardBlock && $dashboard && !empty($containerBlockTypes)) {
-                $formMapper->add('parent', 'Symfony\Bridge\Doctrine\Form\Type\EntityType', [
+                $formMapper->add('parent', EntityType::class, [
                     'class' => $this->getClass(),
                     'query_builder' => function (EntityRepository $repository) use ($dashboard, $containerBlockTypes) {
                         return $repository->createQueryBuilder('a')
@@ -364,7 +369,7 @@ class BlockAdmin extends AbstractAdmin
             }
 
             if ($isComposer) {
-                $formMapper->add('enabled', 'Symfony\Component\Form\Extension\Core\Type\HiddenType', [
+                $formMapper->add('enabled', HiddenType::class, [
                     'data' => true,
                 ]);
             } else {
@@ -372,7 +377,7 @@ class BlockAdmin extends AbstractAdmin
             }
 
             if ($isStandardBlock) {
-                $formMapper->add('position', 'Symfony\Component\Form\Extension\Core\Type\IntegerType');
+                $formMapper->add('position', IntegerType::class);
             }
 
             $formMapper->end();
@@ -388,7 +393,7 @@ class BlockAdmin extends AbstractAdmin
             // When editing a container in composer view, hide some settings
             if ($isContainerRoot && $isComposer) {
                 $formMapper->remove('children');
-                $formMapper->add('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                $formMapper->add('name', TextType::class, [
                     'required' => true,
                 ]);
 
@@ -403,11 +408,11 @@ class BlockAdmin extends AbstractAdmin
         } else {
             $formMapper
                 ->with('form.field_group_options', $optionsGroupOptions)
-                    ->add('type', 'Sonata\BlockBundle\Form\Type\ServiceListType', [
+                    ->add('type', ServiceListType::class, [
                         'context' => 'sonata_dashboard_bundle',
                     ])
                     ->add('enabled')
-                    ->add('position', 'Symfony\Component\Form\Extension\Core\Type\IntegerType')
+                    ->add('position', IntegerType::class)
                 ->end()
             ;
         }

--- a/Admin/DashboardAdmin.php
+++ b/Admin/DashboardAdmin.php
@@ -19,6 +19,7 @@ use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\AdminBundle\Show\ShowMapper;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 
 /**
  * Admin definition for the Dashboard class.
@@ -109,7 +110,7 @@ class DashboardAdmin extends AbstractAdmin
         $formMapper
             ->with('form_dashboard.group_main_label')
                 ->add('name')
-                ->add('enabled', null, ['required' => false])
+                ->add('enabled', CheckboxType::class, ['required' => false])
             ->end()
         ;
 

--- a/Block/ContainerBlockService.php
+++ b/Block/ContainerBlockService.php
@@ -13,7 +13,12 @@ namespace Sonata\DashboardBundle\Block;
 
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\BlockBundle\Block\Service\ContainerBlockService as BaseContainerBlockService;
+use Sonata\BlockBundle\Form\Type\ContainerTemplateType;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Sonata\CoreBundle\Form\Type\CollectionType;
+use Sonata\CoreBundle\Form\Type\ImmutableArrayType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -30,27 +35,27 @@ class ContainerBlockService extends BaseContainerBlockService
     {
         $formMapper->add('enabled');
 
-        $formMapper->add('settings', 'sonata_type_immutable_array', [
+        $formMapper->add('settings', ImmutableArrayType::class, [
             'keys' => [
-                ['code', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                ['code', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_code',
                 ]],
-                ['layout', 'Symfony\Component\Form\Extension\Core\Type\TextareaType', [
+                ['layout', TextareaType::class, [
                     'label' => 'form.label_layout',
                 ]],
-                ['class', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                ['class', TextType::class, [
                     'required' => false,
                     'label' => 'form.label_class',
                 ]],
-                ['template', 'Sonata\BlockBundle\Form\Type\ContainerTemplateType', [
+                ['template', ContainerTemplateType::class, [
                     'label' => 'form.label_template',
                 ]],
             ],
             'translation_domain' => 'SonataDashboardBundle',
         ]);
 
-        $formMapper->add('children', 'sonata_type_collection', [], [
+        $formMapper->add('children', CollectionType::class, [], [
             'admin_code' => 'sonata.dashboard.admin.block',
             'edit' => 'inline',
             'inline' => 'table',


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Changed
- Removed usage of old form type aliases
```
