### PR TITLE
Drop PHPUnit 4

### DIFF
--- a/Tests/Admin/BlockAdminTest.php
+++ b/Tests/Admin/BlockAdminTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\DashboardBundle\Tests\Admin;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\DashboardBundle\Admin\BlockAdmin;
 use Sonata\DashboardBundle\Tests\Fixtures\Entity\FooGetName;
 use Sonata\DashboardBundle\Tests\Fixtures\Entity\FooGetNameNull;
@@ -22,7 +23,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Stéphane Paté <st.pate@orange.fr>
  */
-final class BlockAdminTest extends \PHPUnit_Framework_TestCase
+final class BlockAdminTest extends TestCase
 {
     public function testToString()
     {

--- a/Tests/Block/ContainerBlockServiceTest.php
+++ b/Tests/Block/ContainerBlockServiceTest.php
@@ -92,7 +92,7 @@ class ContainerBlockServiceTest extends AbstractBlockServiceTestCase
             'name' => 'block.code',
         ]);
 
-        $formMapper = $this->getMock('Sonata\\AdminBundle\\Form\\FormMapper', [], [], '', false);
+        $formMapper = $this->createMock('Sonata\\AdminBundle\\Form\\FormMapper', [], [], '', false);
         $formMapper->expects($this->exactly(6))->method('add');
 
         $service->buildCreateForm($formMapper, $block);

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -11,10 +11,11 @@
 
 namespace Sonata\DashboardBundleBundle\Tests\DependencyInjection;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\DashboardBundle\DependencyInjection\Configuration;
 use Symfony\Component\Config\Definition\Processor;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
     public function testClasses()
     {

--- a/Tests/Entity/BlockManagerTest.php
+++ b/Tests/Entity/BlockManagerTest.php
@@ -11,12 +11,13 @@
 
 namespace Sonata\DashboardBundle\Tests\Entity;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\DashboardBundle\Entity\BlockManager;
 
 /**
  * Class BlockManagerTest.
  */
-class BlockManagerTest extends \PHPUnit_Framework_TestCase
+class BlockManagerTest extends TestCase
 {
     public function testGetPager()
     {
@@ -35,7 +36,7 @@ class BlockManagerTest extends \PHPUnit_Framework_TestCase
         $query = $this->getMockForAbstractClass('Doctrine\ORM\AbstractQuery', [], '', false, true, true, ['execute']);
         $query->expects($this->any())->method('execute')->will($this->returnValue(true));
 
-        $qb = $this->getMock('Doctrine\ORM\QueryBuilder', [], [
+        $qb = $this->createMock('Doctrine\ORM\QueryBuilder', [], [
             $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock(),
         ]);
 
@@ -51,7 +52,7 @@ class BlockManagerTest extends \PHPUnit_Framework_TestCase
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock();
         $em->expects($this->any())->method('getRepository')->will($this->returnValue($repository));
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
         return new BlockManager('Sonata\DashboardBundle\Entity\BaseDashboard', $registry);

--- a/Tests/Entity/DashboardManagerTest.php
+++ b/Tests/Entity/DashboardManagerTest.php
@@ -11,12 +11,13 @@
 
 namespace Sonata\DashboardBundle\Tests\Entity;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\DashboardBundle\Entity\DashboardManager;
 
 /**
  * Class DashboardManagerTest.
  */
-class DashboardManagerTest extends \PHPUnit_Framework_TestCase
+class DashboardManagerTest extends TestCase
 {
     public function testGetPager()
     {
@@ -125,7 +126,7 @@ class DashboardManagerTest extends \PHPUnit_Framework_TestCase
         $query = $this->getMockForAbstractClass('Doctrine\ORM\AbstractQuery', [], '', false, true, true, ['execute']);
         $query->expects($this->any())->method('execute')->will($this->returnValue(true));
 
-        $qb = $this->getMock('Doctrine\ORM\QueryBuilder', [], [
+        $qb = $this->createMock('Doctrine\ORM\QueryBuilder', [], [
             $this->getMockBuilder('Doctrine\ORM\EntityManager')->disableOriginalConstructor()->getMock(),
         ]);
 
@@ -137,7 +138,7 @@ class DashboardManagerTest extends \PHPUnit_Framework_TestCase
         $repository = $this->getMockBuilder('Doctrine\ORM\EntityRepository')->disableOriginalConstructor()->getMock();
         $repository->expects($this->any())->method('createQueryBuilder')->will($this->returnValue($qb));
 
-        $metadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $metadata = $this->createMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
         $metadata->expects($this->any())->method('getFieldNames')->will($this->returnValue([
             'name',
             'routeName',
@@ -147,7 +148,7 @@ class DashboardManagerTest extends \PHPUnit_Framework_TestCase
         $em->expects($this->any())->method('getRepository')->will($this->returnValue($repository));
         $em->expects($this->any())->method('getClassMetadata')->will($this->returnValue($metadata));
 
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->createMock('Doctrine\Common\Persistence\ManagerRegistry');
         $registry->expects($this->any())->method('getManagerForClass')->will($this->returnValue($em));
 
         return new DashboardManager('Sonata\DashboardBundle\Entity\BaseDashboard', $registry);

--- a/Tests/Model/BlockInteractorTest.php
+++ b/Tests/Model/BlockInteractorTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\DashboardBundle\Tests\Model;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\BlockBundle\Model\Block;
 use Sonata\DashboardBundle\Entity\BlockInteractor;
 
@@ -21,7 +22,7 @@ use Sonata\DashboardBundle\Entity\BlockInteractor;
  *
  * @author Vincent Composieux <composieux@ekino.com>
  */
-class BlockInteractorTest extends \PHPUnit_Framework_TestCase
+class BlockInteractorTest extends TestCase
 {
     /**
      * Test createNewContainer() method with some values.
@@ -30,7 +31,7 @@ class BlockInteractorTest extends \PHPUnit_Framework_TestCase
     {
         $registry = $this->getMockBuilder('Symfony\Bridge\Doctrine\RegistryInterface')->disableOriginalConstructor()->getMock();
 
-        $blockManager = $this->getMock('Sonata\DashboardBundle\Model\BlockManagerInterface');
+        $blockManager = $this->createMock('Sonata\DashboardBundle\Model\BlockManagerInterface');
         $blockManager->expects($this->any())->method('create')->will($this->returnValue(new Block()));
 
         $blockInteractor = new BlockInteractor($registry, $blockManager, 'sonata.dashboard.block.container');

--- a/Tests/Model/DashboardTest.php
+++ b/Tests/Model/DashboardTest.php
@@ -11,9 +11,10 @@
 
 namespace Sonata\DashboardBundle\Tests\Entity;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\DashboardBundle\Tests\Model\Dashboard;
 
-class DashboardTest extends \PHPUnit_Framework_TestCase
+class DashboardTest extends TestCase
 {
     public function testGetterSetter()
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
Removed compatibility with PHPUnit 4. Fixes: https://github.com/sebastianbergmann/phpunit/issues/2809