### PR TITLE
Add symfony/phpunit-bridge to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "twig/twig": "^1.34 || ^2.0"
     },
     "require-dev": {
-        "sonata-project/doctrine-orm-admin-bundle": "^3.0"
+        "sonata-project/doctrine-orm-admin-bundle": "^3.0",
+        "symfony/phpunit-bridge": "^4.0"
     },
     "suggest": {
         "sonata-project/doctrine-orm-admin-bundle": "^2.2"


### PR DESCRIPTION
I am targeting this branch, because this is BC patch.

## Subject

Travis builds are failed since https://github.com/sonata-project/dev-kit/pull/370. This PR adds `symfony/phpunit-bridge` to composer.json to fix travis builds