### PR TITLE
Removed $parentAssociationMapping

### DIFF
--- a/src/Admin/BlockAdmin.php
+++ b/src/Admin/BlockAdmin.php
@@ -38,16 +38,12 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 final class BlockAdmin extends AbstractAdmin
 {
-    /**
-     * @var string
-     */
-    protected $parentAssociationMapping = 'dashboard';
-
     protected $accessMapping = [
         'savePosition' => 'EDIT',
         'switchParent' => 'EDIT',
         'composePreview' => 'EDIT',
     ];
+
     /**
      * @var BlockServiceManagerInterface
      */


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - master is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDashboardBundle/blob/master/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixed #140

## Subject

The $parentAssociationMapping is not needed anymore.
