### PR TITLE
Added admin icons

### DIFF
--- a/src/Resources/config/admin.xml
+++ b/src/Resources/config/admin.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
+        <parameter key="sonata.dashboard.admin.groupname">sonata_dashboard</parameter>
+        <parameter key="sonata.dashboard.admin.groupicon"><![CDATA[<i class='fa fa-tachometer'></i>]]></parameter>
         <!-- DASHBOARD -->
         <parameter key="sonata.dashboard.admin.dashboard.class">Sonata\DashboardBundle\Admin\DashboardAdmin</parameter>
         <parameter key="sonata.dashboard.admin.dashboard.controller">SonataDashboardBundle:DashboardAdmin</parameter>
@@ -12,7 +14,7 @@
     </parameters>
     <services>
         <service id="sonata.dashboard.admin.dashboard" class="%sonata.dashboard.admin.dashboard.class%" public="true">
-            <tag name="sonata.admin" manager_type="orm" group="sonata_dashboard" label_catalogue="%sonata.dashboard.admin.dashboard.translation_domain%" label="dashboard" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="orm" group="%sonata.dashboard.admin.groupname%" label_catalogue="%sonata.dashboard.admin.dashboard.translation_domain%" label="dashboard" label_translator_strategy="sonata.admin.label.strategy.underscore" icon="%sonata.dashboard.admin.groupicon%"/>
             <argument/>
             <argument>%sonata.dashboard.admin.dashboard.entity%</argument>
             <argument>%sonata.dashboard.admin.dashboard.controller%</argument>
@@ -32,7 +34,7 @@
             </call>
         </service>
         <service id="sonata.dashboard.admin.block" class="%sonata.dashboard.admin.block.class%" public="true">
-            <tag name="sonata.admin" manager_type="orm" show_in_dashboard="false" group="sonata_dashboard" label_catalogue="%sonata.dashboard.admin.dashboard.translation_domain%" label="block" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
+            <tag name="sonata.admin" manager_type="orm" show_in_dashboard="false" group="%sonata.dashboard.admin.groupname%" label_catalogue="%sonata.dashboard.admin.dashboard.translation_domain%" label="block" label_translator_strategy="sonata.admin.label.strategy.underscore" icon="%sonata.dashboard.admin.groupicon%"/>
             <argument/>
             <argument>%sonata.dashboard.admin.block.entity%</argument>
             <argument>%sonata.dashboard.admin.block.controller%</argument>

--- a/src/Resources/translations/SonataDashboardBundle.de.xliff
+++ b/src/Resources/translations/SonataDashboardBundle.de.xliff
@@ -286,6 +286,10 @@
                 <source>notice</source>
                 <target>Hinweis</target>
             </trans-unit>
+            <trans-unit id="72" resname="sonata_dashboard">
+                <source>sonata_dashboard</source>
+                <target>Dashboard</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/SonataDashboardBundle.en.xliff
+++ b/src/Resources/translations/SonataDashboardBundle.en.xliff
@@ -286,6 +286,10 @@
                 <source>notice</source>
                 <target>notice</target>
             </trans-unit>
+            <trans-unit id="72" resname="sonata_dashboard">
+                <source>sonata_dashboard</source>
+                <target>Dashboard</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataPageBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added group icon to admin pages
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->

