### PR TITLE
Remove edited property from Dashboard entity

### DIFF
--- a/src/Admin/BlockAdmin.php
+++ b/src/Admin/BlockAdmin.php
@@ -119,10 +119,6 @@ final class BlockAdmin extends AbstractAdmin
 
         // fix weird bug with setter object not being call
         $object->setChildren($object->getChildren());
-
-        if ($object->getDashboard() instanceof DashboardInterface) {
-            $object->getDashboard()->setEdited(true);
-        }
     }
 
     public function postUpdate($object): void
@@ -162,10 +158,6 @@ final class BlockAdmin extends AbstractAdmin
                 'The '.__METHOD__.'() method is deprecated since sonata-project/dashboard-bundle 0.x and will be removed in version 1.0.',
                 E_USER_DEPRECATED
             );
-        }
-
-        if ($object->getDashboard() instanceof DashboardInterface) {
-            $object->getDashboard()->setEdited(true);
         }
 
         // fix weird bug with setter object not being call

--- a/src/Admin/DashboardAdmin.php
+++ b/src/Admin/DashboardAdmin.php
@@ -55,8 +55,6 @@ final class DashboardAdmin extends AbstractAdmin
         if (!$object instanceof DashboardInterface) {
             throw new \InvalidArgumentException('Invalid dashboard object');
         }
-
-        $object->setEdited(true);
     }
 
     public function prePersist($object): void
@@ -64,8 +62,6 @@ final class DashboardAdmin extends AbstractAdmin
         if (!$object instanceof DashboardInterface) {
             throw new \InvalidArgumentException('Invalid dashboard object');
         }
-
-        $object->setEdited(true);
     }
 
     protected function configureShowFields(ShowMapper $showMapper): void
@@ -74,7 +70,6 @@ final class DashboardAdmin extends AbstractAdmin
             ->add('name')
             ->add('default')
             ->add('enabled')
-            ->add('edited')
         ;
     }
 
@@ -84,7 +79,6 @@ final class DashboardAdmin extends AbstractAdmin
             ->addIdentifier('name')
             ->add('default')
             ->add('enabled', null, ['editable' => true])
-            ->add('edited', null, ['editable' => true])
         ;
     }
 
@@ -92,7 +86,6 @@ final class DashboardAdmin extends AbstractAdmin
     {
         $datagridMapper
             ->add('name')
-            ->add('edited')
         ;
     }
 

--- a/src/Entity/DashboardManager.php
+++ b/src/Entity/DashboardManager.php
@@ -52,11 +52,6 @@ final class DashboardManager extends BaseEntityManager implements DashboardManag
             $parameters['enabled'] = $criteria['enabled'];
         }
 
-        if (isset($criteria['edited'])) {
-            $query->andWhere('d.edited = :edited');
-            $parameters['edited'] = $criteria['edited'];
-        }
-
         $query->setParameters($parameters);
 
         $pager = new Pager();

--- a/src/Model/Dashboard.php
+++ b/src/Model/Dashboard.php
@@ -53,17 +53,11 @@ abstract class Dashboard implements DashboardInterface
     /**
      * @var bool|null
      */
-    protected $edited;
-
-    /**
-     * @var bool|null
-     */
     protected $default;
 
     public function __construct()
     {
         $this->blocks = [];
-        $this->edited = true;
     }
 
     public function __toString()
@@ -127,18 +121,6 @@ abstract class Dashboard implements DashboardInterface
     public function setEnabled(bool $enabled)
     {
         $this->enabled = $enabled;
-
-        return $this;
-    }
-
-    public function getEdited(): bool
-    {
-        return $this->edited ?? false;
-    }
-
-    public function setEdited(bool $edited)
-    {
-        $this->edited = $edited;
 
         return $this;
     }

--- a/src/Model/DashboardInterface.php
+++ b/src/Model/DashboardInterface.php
@@ -48,8 +48,4 @@ interface DashboardInterface
      * @return DashboardBlockInterface[]
      */
     public function getBlocks();
-
-    public function getEdited(): bool;
-
-    public function setEdited(bool $edited);
 }

--- a/src/Resources/config/doctrine/BaseDashboard.orm.xml
+++ b/src/Resources/config/doctrine/BaseDashboard.orm.xml
@@ -6,11 +6,6 @@
                 <option name="default">0</option>
             </options>
         </field>
-        <field name="edited" type="boolean" column="edited">
-            <options>
-                <option name="default">0</option>
-            </options>
-        </field>
         <field name="default" type="boolean" column="is_default">
             <options>
                 <option name="default">0</option>

--- a/src/Resources/translations/SonataDashboardBundle.de.xliff
+++ b/src/Resources/translations/SonataDashboardBundle.de.xliff
@@ -74,10 +74,6 @@
                 <source>list.label_enabled</source>
                 <target>Aktiviert</target>
             </trans-unit>
-            <trans-unit id="18" resname="list.label_edited">
-                <source>list.label_edited</source>
-                <target>bearbeitet</target>
-            </trans-unit>
             <trans-unit id="19" resname="list.label_name">
                 <source>list.label_name</source>
                 <target>Name</target>
@@ -222,10 +218,6 @@
                 <source>filter.label_name</source>
                 <target>Name</target>
             </trans-unit>
-            <trans-unit id="55" resname="filter.label_edited">
-                <source>filter.label_edited</source>
-                <target>Bearbeitet</target>
-            </trans-unit>
             <trans-unit id="56" resname="filter.label_type">
                 <source>filter.label_type</source>
                 <target>Typ</target>
@@ -245,10 +237,6 @@
             <trans-unit id="60" resname="show.label_name">
                 <source>show.label_name</source>
                 <target>Name</target>
-            </trans-unit>
-            <trans-unit id="61" resname="show.label_edited">
-                <source>show.label_edited</source>
-                <target>Bearbeitet</target>
             </trans-unit>
             <trans-unit id="62" resname="sidemenu.link_render_dashboard">
                 <source>sidemenu.link_render_dashboard</source>

--- a/src/Resources/translations/SonataDashboardBundle.en.xliff
+++ b/src/Resources/translations/SonataDashboardBundle.en.xliff
@@ -70,10 +70,6 @@
                 <source>list.label_enabled</source>
                 <target>Enabled</target>
             </trans-unit>
-            <trans-unit id="18" resname="list.label_edited">
-                <source>list.label_edited</source>
-                <target>Edited</target>
-            </trans-unit>
             <trans-unit id="19" resname="list.label_name">
                 <source>list.label_name</source>
                 <target>Name</target>
@@ -218,10 +214,6 @@
                 <source>filter.label_name</source>
                 <target>Name</target>
             </trans-unit>
-            <trans-unit id="55" resname="filter.label_edited">
-                <source>filter.label_edited</source>
-                <target>Edited</target>
-            </trans-unit>
             <trans-unit id="56" resname="filter.label_type">
                 <source>filter.label_type</source>
                 <target>Type</target>
@@ -241,10 +233,6 @@
             <trans-unit id="60" resname="show.label_name">
                 <source>show.label_name</source>
                 <target>Name</target>
-            </trans-unit>
-            <trans-unit id="61" resname="show.label_edited">
-                <source>show.label_edited</source>
-                <target>Edited</target>
             </trans-unit>
             <trans-unit id="62" resname="sidemenu.link_render_dashboard">
                 <source>sidemenu.link_render_dashboard</source>

--- a/src/Resources/translations/SonataDashboardBundle.es.xliff
+++ b/src/Resources/translations/SonataDashboardBundle.es.xliff
@@ -70,10 +70,6 @@
                 <source>list.label_enabled</source>
                 <target>Habilitado</target>
             </trans-unit>
-            <trans-unit id="18" resname="list.label_edited">
-                <source>list.label_edited</source>
-                <target>Editado</target>
-            </trans-unit>
             <trans-unit id="19" resname="list.label_name">
                 <source>list.label_name</source>
                 <target>Nombre</target>
@@ -218,10 +214,6 @@
                 <source>filter.label_name</source>
                 <target>Nombre</target>
             </trans-unit>
-            <trans-unit id="55" resname="filter.label_edited">
-                <source>filter.label_edited</source>
-                <target>Editado</target>
-            </trans-unit>
             <trans-unit id="56" resname="filter.label_type">
                 <source>filter.label_type</source>
                 <target>Tipo</target>
@@ -241,10 +233,6 @@
             <trans-unit id="60" resname="show.label_name">
                 <source>show.label_name</source>
                 <target>Nombre</target>
-            </trans-unit>
-            <trans-unit id="61" resname="show.label_edited">
-                <source>show.label_edited</source>
-                <target>Editado</target>
             </trans-unit>
             <trans-unit id="62" resname="sidemenu.link_render_dashboard">
                 <source>sidemenu.link_render_dashboard</source>

--- a/src/Resources/translations/SonataDashboardBundle.fr.xliff
+++ b/src/Resources/translations/SonataDashboardBundle.fr.xliff
@@ -70,10 +70,6 @@
                 <source>list.label_enabled</source>
                 <target>Activé</target>
             </trans-unit>
-            <trans-unit id="18" resname="list.label_edited">
-                <source>list.label_edited</source>
-                <target>Edité</target>
-            </trans-unit>
             <trans-unit id="19" resname="list.label_name">
                 <source>list.label_name</source>
                 <target>Nom</target>
@@ -218,10 +214,6 @@
                 <source>filter.label_name</source>
                 <target>Nom</target>
             </trans-unit>
-            <trans-unit id="55" resname="filter.label_edited">
-                <source>filter.label_edited</source>
-                <target>Edité</target>
-            </trans-unit>
             <trans-unit id="56" resname="filter.label_type">
                 <source>filter.label_type</source>
                 <target>Type</target>
@@ -241,10 +233,6 @@
             <trans-unit id="60" resname="show.label_name">
                 <source>show.label_name</source>
                 <target>Nom</target>
-            </trans-unit>
-            <trans-unit id="61" resname="show.label_edited">
-                <source>show.label_edited</source>
-                <target>Edité</target>
             </trans-unit>
             <trans-unit id="62" resname="sidemenu.link_render_dashboard">
                 <source>sidemenu.link_render_dashboard</source>

--- a/src/Resources/translations/SonataDashboardBundle.ru.xliff
+++ b/src/Resources/translations/SonataDashboardBundle.ru.xliff
@@ -74,10 +74,6 @@
                 <source>list.label_enabled</source>
                 <target>Включена</target>
             </trans-unit>
-            <trans-unit id="18" resname="list.label_edited">
-                <source>list.label_edited</source>
-                <target>Edited</target>
-            </trans-unit>
             <trans-unit id="19" resname="list.label_name">
                 <source>list.label_name</source>
                 <target>Имя</target>
@@ -222,10 +218,6 @@
                 <source>filter.label_name</source>
                 <target>Имя</target>
             </trans-unit>
-            <trans-unit id="55" resname="filter.label_edited">
-                <source>filter.label_edited</source>
-                <target>Отредактирован</target>
-            </trans-unit>
             <trans-unit id="56" resname="filter.label_type">
                 <source>filter.label_type</source>
                 <target>Тип</target>
@@ -245,10 +237,6 @@
             <trans-unit id="60" resname="show.label_name">
                 <source>show.label_name</source>
                 <target>Имя</target>
-            </trans-unit>
-            <trans-unit id="61" resname="show.label_edited">
-                <source>show.label_edited</source>
-                <target>Отредактирован</target>
             </trans-unit>
         </body>
     </file>

--- a/tests/Entity/DashboardManagerTest.php
+++ b/tests/Entity/DashboardManagerTest.php
@@ -104,30 +104,6 @@ final class DashboardManagerTest extends TestCase
             ->getPager(['enabled' => false], 1);
     }
 
-    public function testGetPagerWithEditedPages(): void
-    {
-        $self = $this;
-        $this
-            ->getDashboardManager(function ($qb) use ($self): void {
-                $qb->expects($self->once())->method('andWhere')->with($self->equalTo('d.edited = :edited'));
-                $qb->expects($self->once())->method('setParameters')->with($self->equalTo(['edited' => true]));
-                $qb->expects($this->any())->method('getRootAliases')->willReturn([]);
-            })
-            ->getPager(['edited' => true], 1);
-    }
-
-    public function testGetPagerWithNonEditedPages(): void
-    {
-        $self = $this;
-        $this
-            ->getDashboardManager(function ($qb) use ($self): void {
-                $qb->expects($self->once())->method('andWhere')->with($self->equalTo('d.edited = :edited'));
-                $qb->expects($self->once())->method('setParameters')->with($self->equalTo(['edited' => false]));
-                $qb->expects($this->any())->method('getRootAliases')->willReturn([]);
-            })
-            ->getPager(['edited' => false], 1);
-    }
-
     private function getDashboardManager($qbCallback)
     {
         $query = $this->getMockForAbstractClass(AbstractQuery::class, [], '', false, true, true, ['execute']);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
This property has no technical usage. 
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - master is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDashboardBundle/blob/master/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a BC break, but we have no stable release yet.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDashboardBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Remove `edited` property from `Dashboard` entity
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
