### PR TITLE
Make SonataEasyExtends optional

### DIFF
--- a/UPGRADE-0.x.md
+++ b/UPGRADE-0.x.md
@@ -1,2 +1,10 @@
 UPGRADE 0.x
 ===========
+
+UPGRADE FROM 0.x to 0.x
+========================
+
+### SonataEasyExtends is replaced by SonataDoctrineBundle
+
+Registering `SonataEasyExtendsBundle` bundle is not needed, it SHOULD NOT be registered.
+Register `SonataDoctrineBundle` bundle instead.

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "doctrine/collections": "^1.6",
         "doctrine/doctrine-bundle": "^1.12 || ^2.0",
         "doctrine/orm": "^2.6",
@@ -29,26 +29,27 @@
         "sonata-project/block-bundle": "^3.18",
         "sonata-project/cache-bundle": "^2.4.2",
         "sonata-project/datagrid-bundle": "^2.3",
-        "sonata-project/doctrine-extensions": "^1.5.1",
-        "sonata-project/easy-extends-bundle": "^2.5",
+        "sonata-project/doctrine-extensions": "^1.8",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
         "sonata-project/notification-bundle": "^3.4",
-        "symfony/config": "^3.4 || ^4.0",
-        "symfony/dependency-injection": "^3.4 || ^4.0",
-        "symfony/doctrine-bridge": "^3.4 || ^4.0",
-        "symfony/form": "^3.4 || ^4.0",
-        "symfony/http-foundation": "^3.4 || ^4.0",
-        "symfony/http-kernel": "^3.4 || ^4.0",
-        "symfony/options-resolver": "^3.4 || ^4.0",
-        "symfony/security-core": "^3.4 || ^4.0",
-        "symfony/security-http": "^3.4 || ^4.0",
-        "twig/twig": "^1.41 || ^2.10"
+        "symfony/config": "^4.4",
+        "symfony/dependency-injection": "^4.4",
+        "symfony/doctrine-bridge": "^4.4",
+        "symfony/form": "^4.4",
+        "symfony/http-foundation": "^4.4",
+        "symfony/http-kernel": "^4.4",
+        "symfony/options-resolver": "^4.4",
+        "symfony/security-core": "^4.4",
+        "symfony/security-http": "^4.4",
+        "twig/twig": "^2.12"
     },
     "conflict": {
         "sonata-project/core-bundle": "<3.20"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^5.0"
+        "matthiasnoback/symfony-config-test": "^4.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.0",
+        "symfony/phpunit-bridge": "^5.1"
     },
     "config": {
         "sort-packages": true

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -34,15 +34,9 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('sonata_dashboard');
+        $rootNode = $treeBuilder->getRootNode();
 
-        // Keep compatibility with symfony/config < 4.2
-        if (!method_exists($treeBuilder, 'getRootNode')) {
-            $node = $treeBuilder->root('sonata_dashboard')->children();
-        } else {
-            $node = $treeBuilder->getRootNode()->children();
-        }
-
-        $node
+        $rootNode->children()
             ->arrayNode('class')
                 ->addDefaultsIfNotSet()
                 ->children()

--- a/src/DependencyInjection/SonataDashboardExtension.php
+++ b/src/DependencyInjection/SonataDashboardExtension.php
@@ -42,11 +42,11 @@ final class SonataDashboardExtension extends Extension
         $loader->load('orm.xml');
         $loader->load('twig.xml');
 
-        if (isset($bundles['SonataDoctrineBundle'])) {
-            $this->registerSonataDoctrineMapping($config);
-        } else {
+        if (!isset($bundles['SonataDoctrineBundle'])) {
             throw new \RuntimeException('You must register SonataDoctrineBundle to use SonataDashboardBundle.');
         }
+            
+        $this->registerSonataDoctrineMapping($config);
 
         $this->registerParameters($container, $config);
     }

--- a/src/DependencyInjection/SonataDashboardExtension.php
+++ b/src/DependencyInjection/SonataDashboardExtension.php
@@ -45,7 +45,7 @@ final class SonataDashboardExtension extends Extension
         if (!isset($bundles['SonataDoctrineBundle'])) {
             throw new \RuntimeException('You must register SonataDoctrineBundle to use SonataDashboardBundle.');
         }
-            
+       
         $this->registerSonataDoctrineMapping($config);
 
         $this->registerParameters($container, $config);

--- a/src/DependencyInjection/SonataDashboardExtension.php
+++ b/src/DependencyInjection/SonataDashboardExtension.php
@@ -45,7 +45,7 @@ final class SonataDashboardExtension extends Extension
         if (!isset($bundles['SonataDoctrineBundle'])) {
             throw new \RuntimeException('You must register SonataDoctrineBundle to use SonataDashboardBundle.');
         }
-       
+
         $this->registerSonataDoctrineMapping($config);
 
         $this->registerParameters($container, $config);

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -11,40 +11,41 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Sonata\DashboardBundleBundle\Tests\DependencyInjection;
+namespace Sonata\DashboardBundle\Tests\DependencyInjection;
 
-use PHPUnit\Framework\TestCase;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionConfigurationTestCase;
 use Sonata\DashboardBundle\DependencyInjection\Configuration;
-use Symfony\Component\Config\Definition\Processor;
+use Sonata\DashboardBundle\DependencyInjection\SonataDashboardExtension;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
-final class ConfigurationTest extends TestCase
+final class ConfigurationTest extends AbstractExtensionConfigurationTestCase
 {
-    public function testClasses(): void
+    public function testDefault(): void
     {
-        $processor = new Processor();
-
-        $config = $processor->processConfiguration(new Configuration(), [[
+        $this->assertProcessedConfigurationEquals([
             'class' => [
-                'dashboard' => 'MyApp\\Sonata\\DashboardBundle\\Entity\\Dashboard',
+                'dashboard' => 'Application\Sonata\DashboardBundle\Entity\Dashboard',
+                'block' => 'Application\Sonata\DashboardBundle\Entity\Block',
             ],
             'templates' => [
-                'compose' => '@My/MyController/my_template.html.twig',
-            ],
-        ]]);
-
-        $expected = [
-            'class' => [
-                'dashboard' => 'MyApp\\Sonata\\DashboardBundle\\Entity\\Dashboard',
-                'block' => 'Application\\Sonata\\DashboardBundle\\Entity\\Block',
-            ],
-            'templates' => [
-                'compose' => '@My/MyController/my_template.html.twig',
+                'compose' => '@SonataDashboard/DashboardAdmin/compose.html.twig',
                 'compose_container_show' => '@SonataDashboard/DashboardAdmin/compose_container_show.html.twig',
                 'render' => '@SonataDashboard/DashboardAdmin/render.html.twig',
             ],
             'default_container' => 'sonata.dashboard.block.container',
-        ];
+        ], [
+            __DIR__.'/../Fixtures/configuration.yaml',
+        ]);
+    }
 
-        $this->assertSame($expected, $config);
+    protected function getContainerExtension(): ExtensionInterface
+    {
+        return new SonataDashboardExtension();
+    }
+
+    protected function getConfiguration(): ConfigurationInterface
+    {
+        return new Configuration();
     }
 }

--- a/tests/DependencyInjection/SonataDashboardExtensionTest.php
+++ b/tests/DependencyInjection/SonataDashboardExtensionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DashboardBundle\Tests\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sonata\DashboardBundle\Admin\BlockAdmin;
+use Sonata\DashboardBundle\Admin\DashboardAdmin;
+use Sonata\DashboardBundle\Block\ContainerBlockService;
+use Sonata\DashboardBundle\CmsManager\CmsDashboardManager;
+use Sonata\DashboardBundle\CmsManager\CmsManagerSelector;
+use Sonata\DashboardBundle\DependencyInjection\SonataDashboardExtension;
+use Sonata\DashboardBundle\Entity\BlockInteractor;
+use Sonata\DashboardBundle\Entity\BlockManager;
+use Sonata\DashboardBundle\Entity\DashboardManager;
+use Sonata\DashboardBundle\Listener\RequestListener;
+use Sonata\DashboardBundle\Twig\Extension\DashboardExtension;
+use Sonata\DashboardBundle\Twig\GlobalVariables;
+
+final class SonataDashboardExtensionTest extends AbstractExtensionTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->container->setParameter('kernel.bundles', ['SonataDoctrineBundle' => true]);
+    }
+
+    public function testLoadDefault(): void
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasService('sonata.dashboard.admin.dashboard', DashboardAdmin::class);
+        $this->assertContainerBuilderHasService('sonata.dashboard.admin.block', BlockAdmin::class);
+        $this->assertContainerBuilderHasService('sonata.dashboard.block.container', ContainerBlockService::class);
+        $this->assertContainerBuilderHasService('sonata.dashboard.cms.dashboard', CmsDashboardManager::class);
+        $this->assertContainerBuilderHasService('sonata.dashboard.cms_manager_selector', CmsManagerSelector::class);
+        $this->assertContainerBuilderHasService('sonata.dashboard.kernel.request_listener', RequestListener::class);
+        $this->assertContainerBuilderHasService('sonata.dashboard.manager.dashboard', DashboardManager::class);
+        $this->assertContainerBuilderHasService('sonata.dashboard.manager.block', BlockManager::class);
+        $this->assertContainerBuilderHasService('sonata.dashboard.block_interactor', BlockInteractor::class);
+        $this->assertContainerBuilderHasService('sonata.dashboard.twig.extension', DashboardExtension::class);
+        $this->assertContainerBuilderHasService('sonata.dashboard.twig.global', GlobalVariables::class);
+
+        $this->assertContainerBuilderHasParameter('sonata.dashboard.admin.groupname', 'sonata_dashboard');
+        $this->assertContainerBuilderHasParameter('sonata.dashboard.admin.groupicon', "<i class='fa fa-tachometer'></i>");
+        $this->assertContainerBuilderHasParameter('sonata.dashboard.admin.dashboard.class', DashboardAdmin::class);
+        $this->assertContainerBuilderHasParameter('sonata.dashboard.admin.dashboard.controller', 'SonataDashboardBundle:DashboardAdmin');
+        $this->assertContainerBuilderHasParameter('sonata.dashboard.admin.dashboard.translation_domain', 'SonataDashboardBundle');
+        $this->assertContainerBuilderHasParameter('sonata.dashboard.admin.block.class', BlockAdmin::class);
+        $this->assertContainerBuilderHasParameter('sonata.dashboard.admin.block.controller', 'SonataDashboardBundle:BlockAdmin');
+        $this->assertContainerBuilderHasParameter('sonata.dashboard.admin.block.translation_domain', '%sonata.dashboard.admin.dashboard.translation_domain%');
+        $this->assertContainerBuilderHasParameter('sonata.dashboard.block.container.class', ContainerBlockService::class);
+        $this->assertContainerBuilderHasParameter('sonata.dashboard.manager.dashboard.class', DashboardManager::class);
+        $this->assertContainerBuilderHasParameter('sonata.dashboard.manager.block.class', BlockManager::class);
+        $this->assertContainerBuilderHasParameter('sonata.dashboard.block_interactor.class', BlockInteractor::class);
+        $this->assertContainerBuilderHasParameter('sonata.dashboard.block.class', 'Application\Sonata\DashboardBundle\Entity\Block');
+        $this->assertContainerBuilderHasParameter('sonata.dashboard.dashboard.class', 'Application\Sonata\DashboardBundle\Entity\Dashboard');
+        $this->assertContainerBuilderHasParameter('sonata.dashboard.admin.block.entity', 'Application\Sonata\DashboardBundle\Entity\Block');
+        $this->assertContainerBuilderHasParameter('sonata.dashboard.admin.dashboard.entity', 'Application\Sonata\DashboardBundle\Entity\Dashboard');
+        $this->assertContainerBuilderHasParameter('sonata.dashboard.admin.dashboard.templates.compose', '@SonataDashboard/DashboardAdmin/compose.html.twig');
+        $this->assertContainerBuilderHasParameter('sonata.dashboard.admin.dashboard.templates.compose_container_show', '@SonataDashboard/DashboardAdmin/compose_container_show.html.twig');
+        $this->assertContainerBuilderHasParameter('sonata.dashboard.admin.dashboard.templates.render', '@SonataDashboard/DashboardAdmin/render.html.twig');
+        $this->assertContainerBuilderHasParameter('sonata.dashboard.default_container', 'sonata.dashboard.block.container');
+    }
+
+    protected function getContainerExtensions(): array
+    {
+        return [
+            new SonataDashboardExtension(),
+        ];
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataArticleBundle/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

Part of: https://github.com/sonata-project/dev-kit/issues/750

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

SonataEasyExtends is deprecated but it is used on many bundles, this makes it optional. This change is BC because if the user does not change anything it will continue using the deprecated code but with a message.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataArticleBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- SonataEasyExtendsBundle is not used anymore, use SonataDoctrineBundle
### Removed
- Support for Symfony < 4.4
```

## To do

- [x] Update the documentation;
- [x] Add an upgrade note.
