### PR TITLE
Allow "symfony/options-resolver:^5.1" and "twig/twig:^3.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,10 +37,10 @@
         "symfony/form": "^4.4",
         "symfony/http-foundation": "^4.4",
         "symfony/http-kernel": "^4.4",
-        "symfony/options-resolver": "^4.4",
+        "symfony/options-resolver": "^4.4 || ^5.1",
         "symfony/security-core": "^4.4",
         "symfony/security-http": "^4.4",
-        "twig/twig": "^2.12"
+        "twig/twig": "^2.12 || ^3.0"
     },
     "conflict": {
         "sonata-project/core-bundle": "<3.20"
@@ -48,7 +48,7 @@
     "require-dev": {
         "matthiasnoback/symfony-config-test": "^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
-        "symfony/phpunit-bridge": "^5.1"
+        "symfony/phpunit-bridge": "^5.1.1"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Allow "symfony/options-resolver:^5.1" and "twig/twig:^3.0".
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - master is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDashboardBundle/blob/master/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataDashboardBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support for "symfony/options-resolver:^5.1";
- Added support for "twig/twig:^3.0".
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
