### PR TITLE
Register StringExtension to support u filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "symfony/security-core": "^4.4",
         "symfony/security-http": "^4.4",
         "symfony/string": "^5.1",
+        "twig/string-extra": "^3.1",
         "twig/twig": "^2.12 || ^3.0"
     },
     "conflict": {

--- a/src/DependencyInjection/Compiler/TwigStringExtensionCompilerPass.php
+++ b/src/DependencyInjection/Compiler/TwigStringExtensionCompilerPass.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DashboardBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Twig\Extra\String\StringExtension;
+
+final class TwigStringExtensionCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->findTaggedServiceIds('twig.extension') as $id => $attributes) {
+            if (StringExtension::class === $container->getDefinition($id)->getClass()) {
+                return;
+            }
+        }
+
+        $definition = new Definition(StringExtension::class);
+        $definition->addTag('twig.extension');
+        $container->setDefinition(StringExtension::class, $definition);
+    }
+}

--- a/tests/DependencyInjection/Compiler/TwigStringExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/TwigStringExtensionCompilerPassTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DashboardBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\DashboardBundle\DependencyInjection\Compiler\TwigStringExtensionCompilerPass;
+use Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\TwigEnvironmentPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Twig\Extra\String\StringExtension;
+
+class TwigStringExtensionCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    public function testLoadTwigStringExtension(): void
+    {
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(StringExtension::class, 'twig.extension');
+    }
+
+    public function testLoadTwigStringExtensionWithExtraBundle(): void
+    {
+        $definition = new Definition(StringExtension::class);
+        $definition->addTag('twig.extension');
+        $this->container->setDefinition('twig.extension.string', $definition);
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('twig.extension.string', 'twig.extension');
+        $this->assertContainerBuilderNotHasService(StringExtension::class);
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new TwigEnvironmentPass());
+        $container->addCompilerPass(new TwigStringExtensionCompilerPass());
+    }
+}


### PR DESCRIPTION
In https://github.com/sonata-project/SonataDashboardBundle/pull/277 `symfony/string` dependency was added, but in order to use "u" filter we have to also add `twig/string-extra` and register the twig extension.

The compiler pass has been copied from `sonata-project/admin-bundle`.

I've labeled as _pedantic_ since there has been no release since that PR.